### PR TITLE
Add GET /api/sheets endpoint to list sheet names

### DIFF
--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -29,7 +29,8 @@ import {
   UpdateSheetRequestSchema,
   UpdateSheetResponseSchema,
   SheetIdParamSchema,
-  DeleteSheetResponseSchema
+  DeleteSheetResponseSchema,
+  GetSheetsResponseSchema
 } from './api-schemas';
 
 // POST /api/roles - Create a new role
@@ -521,6 +522,46 @@ export const deleteUserRoute = createRoute({
   },
 });
 
+// GET /api/sheets - Get list of sheets
+export const getSheetsRoute = createRoute({
+  method: 'get',
+  path: '/api/sheets',
+  summary: 'Get list of sheets',
+  description: 'Returns a list of all sheets in the spreadsheet with their IDs and names',
+  tags: ['Sheets'],
+  security: [{ BearerAuth: [] }],
+  request: {
+    headers: z.object({
+      authorization: z.string().regex(/^Bearer .+/, "Must be in format 'Bearer <token>'")
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: GetSheetsResponseSchema,
+        },
+      },
+      description: 'Sheet list retrieved successfully',
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: UnauthorizedErrorSchema,
+        },
+      },
+      description: 'Authentication failed',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ServerErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
 
 // POST /api/sheets - Create a new sheet
 export const createSheetRoute = createRoute({

--- a/src/api-schemas.ts
+++ b/src/api-schemas.ts
@@ -255,3 +255,16 @@ export const DeleteSheetResponseSchema = z.object({
 	success: z.literal(true),
 	data: z.object({})
 });
+
+// Sheet list schema
+export const SheetListItemSchema = z.object({
+	sheetId: z.number(),
+	name: z.string()
+});
+
+export const GetSheetsResponseSchema = z.object({
+	success: z.literal(true),
+	data: z.object({
+		sheets: z.array(SheetListItemSchema)
+	})
+});

--- a/src/api/sheet.ts
+++ b/src/api/sheet.ts
@@ -9,7 +9,7 @@ import {
   isTokenValid,
   type DatabaseConnection
 } from '../google-auth';
-import { createSheetRoute, updateSheetRoute, deleteSheetRoute } from '../api-routes';
+import { getSheetsRoute, createSheetRoute, updateSheetRoute, deleteSheetRoute } from '../api-routes';
 import { authenticateSession } from './auth';
 import { getMultipleConfigsFromSheet, getUserFromSheet } from '../utils/sheet-helpers';
 
@@ -537,6 +537,99 @@ async function deleteGoogleSheet(
 
 // Sheet management endpoints
 export function registerSheetRoutes(app: OpenAPIHono<{ Bindings: Bindings }>) {
+	// GET /api/sheets - シート一覧を取得 (OpenAPI)
+	app.openapi(getSheetsRoute, async (c) => {
+		try {
+			const db = drizzle(c.env.DB);
+			
+			// 認証ヘッダーからセッションIDを取得
+			const authHeader = c.req.valid('header').authorization;
+			const sessionId = authHeader.replace('Bearer ', '');
+			
+			// セッション認証
+			const authResult = await authenticateSession(db, sessionId);
+			if (!authResult.valid) {
+				return c.json({ success: false as false, error: authResult.error || 'Authentication failed' }, 401);
+			}
+			
+			const userId = authResult.userId;
+			if (!userId) {
+				return c.json({ success: false as false, error: 'User ID not found in session' }, 401);
+			}
+			
+			// Google Sheetsの設定を取得
+			const spreadsheetId = await getConfig(db, 'spreadsheet_id');
+			if (!spreadsheetId) {
+				return c.json({ success: false as false, error: 'No spreadsheet selected' }, 500);
+			}
+			
+			// 有効なGoogleトークンを取得
+			let tokens = await getGoogleTokens(db);
+			if (!tokens) {
+				return c.json({ success: false as false, error: 'No valid Google token found' }, 500);
+			}
+			
+			// トークンの有効性を確認し、必要に応じてリフレッシュ
+			const isValid = await isTokenValid(db);
+			if (!isValid) {
+				const credentials = await getGoogleCredentials(db);
+				if (credentials && tokens.refresh_token) {
+					tokens = await refreshAccessToken(tokens.refresh_token, credentials);
+					await saveGoogleTokens(db, tokens);
+				} else {
+					return c.json({ success: false as false, error: 'Failed to refresh Google token' }, 500);
+				}
+			}
+			
+			// スプレッドシートのメタデータを取得してシート一覧を取得
+			try {
+				const metadataResponse = await fetch(
+					`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}`,
+					{
+						headers: {
+							'Authorization': `Bearer ${tokens.access_token}`,
+							'Content-Type': 'application/json',
+						}
+					}
+				);
+
+				if (!metadataResponse.ok) {
+					return c.json({ success: false as false, error: 'Failed to fetch spreadsheet metadata' }, 500);
+				}
+
+				const metadata = await metadataResponse.json() as any;
+				const sheets = metadata.sheets || [];
+				
+				// システムシート（_で始まるシート）を除外してシート一覧を作成
+				const sheetList = sheets
+					.filter((sheet: any) => !sheet.properties.title.startsWith('_'))
+					.map((sheet: any) => ({
+						sheetId: sheet.properties.sheetId,
+						name: sheet.properties.title
+					}));
+				
+				console.log('Sheets retrieved successfully:', sheetList.length);
+				
+				// 成功レスポンスを返す
+				return c.json({
+					success: true as true,
+					data: {
+						sheets: sheetList
+					}
+				});
+				
+			} catch (error) {
+				console.error('Error fetching sheets:', error);
+				return c.json({ success: false as false, error: 'Failed to fetch sheet list' }, 500);
+			}
+			
+		} catch (error) {
+			console.error('Error in GET /api/sheets:', error);
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			return c.json({ success: false as false, error: errorMessage }, 500);
+		}
+	});
+
 	// POST /api/sheets - 新しいシートを作成 (OpenAPI)
 	app.openapi(createSheetRoute, async (c) => {
 		try {

--- a/templates/playground.html
+++ b/templates/playground.html
@@ -283,6 +283,9 @@
         <div class="section sheets-section">
             <h2>📊 Sheet Management</h2>
             
+            <h3>Get Sheets List</h3>
+            <button onclick="getSheetsList()" class="success">Get Sheets List</button>
+            
             <h3>Create Sheet</h3>
             <div class="row">
                 <div class="col">
@@ -578,6 +581,21 @@
         }
 
         // Sheet functions
+        async function getSheetsList() {
+            try {
+                const headers = getAuthHeaders();
+                const response = await fetch('/api/sheets', {
+                    method: 'GET',
+                    headers
+                });
+                const data = await response.json();
+                
+                showResult('sheetsResult', data, !data.success);
+            } catch (error) {
+                showResult('sheetsResult', { error: error.message }, true);
+            }
+        }
+
         async function createSheet() {
             try {
                 const headers = getAuthHeaders();


### PR DESCRIPTION
- Added schema and route definition for GET /api/sheets
- Implemented handler that returns sheet ID and name list
- Excludes system sheets (starting with _)
- Added playground UI button to test the endpoint
- Returns JSON response with success flag and sheets array

🤖 Generated with [Claude Code](https://claude.ai/code)