### PR TITLE
Remove default name column from sheet creation

### DIFF
--- a/src/api/sheet.ts
+++ b/src/api/sheet.ts
@@ -319,13 +319,13 @@ async function createGoogleSheet(
 	try {
 		// デフォルトカラムを定義
 		const defaultColumns = [
-			'id', 'name', 'created_at', 'updated_at', 'public_read', 'public_write', 
+			'id', 'created_at', 'updated_at', 'public_read', 'public_write', 
 			'role_read', 'role_write', 'user_read', 'user_write'
 		];
 		
 		// デフォルトカラムの型を定義
 		const defaultColumnTypes = [
-			'string', 'string', 'datetime', 'datetime', 'boolean', 'boolean',
+			'string', 'datetime', 'datetime', 'boolean', 'boolean',
 			'array', 'array', 'array', 'array'
 		];
 


### PR DESCRIPTION
Removes the default name column from sheet creation in POST /api/sheets endpoint.

## Changes
- Removed 'name' from defaultColumns array in createGoogleSheet function
- Removed corresponding 'string' type from defaultColumnTypes array

The POST /api/sheets endpoint will no longer create a default 'name' column when creating new sheets.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)