### PR TITLE
feat: implement localStorage for session tokens in playground

### DIFF
--- a/src/playground-html.ts
+++ b/src/playground-html.ts
@@ -390,6 +390,9 @@ export const playgroundHTML = `<!DOCTYPE html>
     </div>
 
     <script>
+        // Constants
+        const SESSION_TOKEN_KEY = 'sheet-db-session-token';
+
         // Helper functions
         function getAuthHeaders() {
             const token = document.getElementById('sessionToken').value.trim();
@@ -400,6 +403,32 @@ export const playgroundHTML = `<!DOCTYPE html>
                 'Authorization': token.startsWith('Bearer ') ? token : \`Bearer \${token}\`,
                 'Content-Type': 'application/json'
             };
+        }
+
+        // LocalStorage functions
+        function saveTokenToStorage(token) {
+            try {
+                localStorage.setItem(SESSION_TOKEN_KEY, token);
+            } catch (error) {
+                console.error('Failed to save token to localStorage:', error);
+            }
+        }
+
+        function loadTokenFromStorage() {
+            try {
+                return localStorage.getItem(SESSION_TOKEN_KEY) || '';
+            } catch (error) {
+                console.error('Failed to load token from localStorage:', error);
+                return '';
+            }
+        }
+
+        function clearTokenFromStorage() {
+            try {
+                localStorage.removeItem(SESSION_TOKEN_KEY);
+            } catch (error) {
+                console.error('Failed to clear token from localStorage:', error);
+            }
         }
 
         function showResult(elementId, data, isError = false) {
@@ -448,6 +477,12 @@ export const playgroundHTML = `<!DOCTYPE html>
                 const response = await fetch('/api/users/me', { headers });
                 const data = await response.json();
                 
+                // Save token to localStorage if user info request succeeds
+                if (data.success) {
+                    const token = document.getElementById('sessionToken').value.trim();
+                    saveTokenToStorage(token);
+                }
+                
                 showResult('authResult', data, !data.success);
                 updateAuthStatus();
             } catch (error) {
@@ -457,6 +492,8 @@ export const playgroundHTML = `<!DOCTYPE html>
 
         function clearAuth() {
             document.getElementById('sessionToken').value = '';
+            // Clear token from localStorage
+            clearTokenFromStorage();
             updateAuthStatus();
             showResult('authResult', { message: '認証情報をクリアしました' });
         }
@@ -672,6 +709,13 @@ export const playgroundHTML = `<!DOCTYPE html>
 
         // Initialize
         document.getElementById('sessionToken').addEventListener('input', updateAuthStatus);
+        
+        // Load token from localStorage on page load
+        const savedToken = loadTokenFromStorage();
+        if (savedToken) {
+            document.getElementById('sessionToken').value = savedToken;
+        }
+        
         updateAuthStatus();
     </script>
 </body>

--- a/templates/playground.html
+++ b/templates/playground.html
@@ -415,6 +415,9 @@
     </div>
 
     <script>
+        // Constants
+        const SESSION_TOKEN_KEY = 'sheet-db-session-token';
+
         // Helper functions
         function getAuthHeaders() {
             const token = document.getElementById('sessionToken').value.trim();
@@ -425,6 +428,32 @@
                 'Authorization': token.startsWith('Bearer ') ? token : `Bearer ${token}`,
                 'Content-Type': 'application/json'
             };
+        }
+
+        // LocalStorage functions
+        function saveTokenToStorage(token) {
+            try {
+                localStorage.setItem(SESSION_TOKEN_KEY, token);
+            } catch (error) {
+                console.error('Failed to save token to localStorage:', error);
+            }
+        }
+
+        function loadTokenFromStorage() {
+            try {
+                return localStorage.getItem(SESSION_TOKEN_KEY) || '';
+            } catch (error) {
+                console.error('Failed to load token from localStorage:', error);
+                return '';
+            }
+        }
+
+        function clearTokenFromStorage() {
+            try {
+                localStorage.removeItem(SESSION_TOKEN_KEY);
+            } catch (error) {
+                console.error('Failed to clear token from localStorage:', error);
+            }
         }
 
         function showResult(elementId, data, isError = false) {
@@ -473,6 +502,12 @@
                 const response = await fetch('/api/users/me', { headers });
                 const data = await response.json();
                 
+                // Save token to localStorage if user info request succeeds
+                if (data.success) {
+                    const token = document.getElementById('sessionToken').value.trim();
+                    saveTokenToStorage(token);
+                }
+                
                 showResult('authResult', data, !data.success);
                 updateAuthStatus();
             } catch (error) {
@@ -482,6 +517,8 @@
 
         function clearAuth() {
             document.getElementById('sessionToken').value = '';
+            // Clear token from localStorage
+            clearTokenFromStorage();
             updateAuthStatus();
             showResult('authResult', { message: 'Authentication information cleared' });
         }
@@ -793,6 +830,13 @@
 
         // Initialize
         document.getElementById('sessionToken').addEventListener('input', updateAuthStatus);
+        
+        // Load token from localStorage on page load
+        const savedToken = loadTokenFromStorage();
+        if (savedToken) {
+            document.getElementById('sessionToken').value = savedToken;
+        }
+        
         updateAuthStatus();
     </script>
 </body>


### PR DESCRIPTION
Implements localStorage functionality for session tokens in the playground according to issue #11 requirements.

## Changes
- Add localStorage persistence for session tokens
- Save token to localStorage when Get User Info succeeds
- Load saved token on page reload
- Clear token from localStorage when Clear Authentication is used
- Add error handling for localStorage operations
- Apply changes to both TypeScript and HTML template versions
- All code comments written in English

Closes #11

Generated with [Claude Code](https://claude.ai/code)