### PR TITLE
Add column modification permission system

### DIFF
--- a/src/api/sheet.ts
+++ b/src/api/sheet.ts
@@ -118,6 +118,75 @@ async function checkSheetUpdatePermission(
 	}
 }
 
+// Check column modification permission helper function
+async function checkColumnModifyPermission(
+	userId: string,
+	userRoles: string[],
+	spreadsheetId: string,
+	accessToken: string
+): Promise<{ allowed: boolean; error?: string }> {
+	try {
+		// Get column modification settings from _Config sheet
+		const configs = await getMultipleConfigsFromSheet(
+			['MODIFY_COLUMNS_BY_API', 'MODIFY_SHEET_USER', 'MODIFY_SHEET_ROLE'], 
+			spreadsheetId, 
+			accessToken
+		);
+		
+		const modifyColumnsByApi = configs['MODIFY_COLUMNS_BY_API'];
+		const modifySheetUser = configs['MODIFY_SHEET_USER'];
+		const modifySheetRole = configs['MODIFY_SHEET_ROLE'];
+
+		// If MODIFY_COLUMNS_BY_API is false, column modification via API is disabled
+		if (modifyColumnsByApi === 'false' || !modifyColumnsByApi) {
+			return { allowed: false, error: 'Column modification via API is disabled' };
+		}
+
+		// Check if user is in MODIFY_SHEET_USER list
+		if (modifySheetUser && modifySheetUser !== '') {
+			try {
+				const allowedUsers = JSON.parse(modifySheetUser);
+				if (Array.isArray(allowedUsers) && !allowedUsers.includes(userId)) {
+					return { allowed: false, error: 'User not authorized to modify columns' };
+				}
+			} catch (e) {
+				// If JSON parsing fails, treat as single user ID
+				if (modifySheetUser !== userId) {
+					return { allowed: false, error: 'User not authorized to modify columns' };
+				}
+			}
+		}
+
+		// Check if user has required role in MODIFY_SHEET_ROLE
+		if (modifySheetRole && modifySheetRole !== '') {
+			try {
+				const allowedRoles = JSON.parse(modifySheetRole);
+				if (Array.isArray(allowedRoles)) {
+					const hasRequiredRole = userRoles.some(role => allowedRoles.includes(role));
+					if (!hasRequiredRole) {
+						return { allowed: false, error: 'User role not authorized to modify columns' };
+					}
+				}
+			} catch (e) {
+				// If JSON parsing fails, treat as single role name
+				if (!userRoles.includes(modifySheetRole)) {
+					return { allowed: false, error: 'User role not authorized to modify columns' };
+				}
+			}
+		}
+
+		// If MODIFY_COLUMNS_BY_API is true but no user/role restrictions, deny by default
+		if ((!modifySheetUser || modifySheetUser === '') && (!modifySheetRole || modifySheetRole === '')) {
+			return { allowed: false, error: 'No users or roles configured for column modification' };
+		}
+
+		return { allowed: true };
+	} catch (error) {
+		console.error('Error checking column modification permission:', error);
+		return { allowed: false, error: 'Failed to check permissions' };
+	}
+}
+
 // シート読み取り権限をチェックするヘルパー関数
 async function checkSheetReadPermission(
 	userId: string | null,
@@ -1328,11 +1397,12 @@ export function registerSheetRoutes(app: OpenAPIHono<{ Bindings: Bindings }>) {
 				return c.json({ success: false as false, error: 'Failed to get sheet information' }, 500);
 			}
 			
-			// シート更新権限をチェック（列追加は更新権限が必要）
-			const permissionCheck = await checkSheetUpdatePermission(
+			// Check column modification permission
+			const permissionCheck = await checkColumnModifyPermission(
 				userId,
 				user.roles || [],
-				metadata
+				spreadsheetId,
+				tokens.access_token
 			);
 			
 			if (!permissionCheck.allowed) {

--- a/src/sheet-schema.ts
+++ b/src/sheet-schema.ts
@@ -723,7 +723,7 @@ export class SheetsSetupManager {
     
     try {
       // Check if data already exists
-      const existingData = await this.getSheetData('_Config', 'A3:C8');
+      const existingData = await this.getSheetData('_Config', 'A3:K8');
       if (existingData?.values && existingData.values.length > 0) {
         console.log('Configuration data already exists, skipping initialization');
         return;

--- a/src/sheet-schema.ts
+++ b/src/sheet-schema.ts
@@ -166,6 +166,14 @@ export class SheetsSetupManager {
           
           await this.styleHeaderRows(schema);
           
+          // Add initial data for _Config sheet
+          if (schema.name === '_Config') {
+            progress.currentStep = 'Adding initial configuration...';
+            if (progressCallback) progressCallback(progress);
+            
+            await this.addInitialConfigData();
+          }
+          
           completedSheets.push(schema.name);
           console.log('Schema processed successfully:', schema.name);
           
@@ -707,6 +715,42 @@ export class SheetsSetupManager {
       console.error('Error styling header rows for sheet:', schema.name, error);
       // Treat styling errors as warnings and continue setup
       console.warn('Continuing setup despite header styling error');
+    }
+  }
+  
+  private async addInitialConfigData(): Promise<void> {
+    console.log('Adding initial configuration data to _Config sheet');
+    
+    try {
+      // Check if data already exists
+      const existingData = await this.getSheetData('_Config', 'A3:C8');
+      if (existingData?.values && existingData.values.length > 0) {
+        console.log('Configuration data already exists, skipping initialization');
+        return;
+      }
+      
+      // Prepare initial configuration values
+      const configData = [
+        ['CREATE_SHEET_BY_API', 'CREATE_SHEET_BY_API', 'false', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['CREATE_SHEET_USER', 'CREATE_SHEET_USER', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['CREATE_SHEET_ROLE', 'CREATE_SHEET_ROLE', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['MODIFY_COLUMNS_BY_API', 'MODIFY_COLUMNS_BY_API', 'false', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['MODIFY_SHEET_USER', 'MODIFY_SHEET_USER', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['MODIFY_SHEET_ROLE', 'MODIFY_SHEET_ROLE', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]']
+      ];
+      
+      // Update sheet with initial configuration
+      await this.updateSheetData([{
+        range: '_Config!A3:K8',
+        values: configData
+      }]);
+      
+      console.log('Initial configuration data added successfully');
+      
+    } catch (error) {
+      console.error('Error adding initial configuration data:', error);
+      // Continue setup even if initial data fails
+      console.warn('Continuing setup despite initial data error');
     }
   }
 }


### PR DESCRIPTION
- Add checkColumnModifyPermission function to validate column operations
- Check MODIFY_COLUMNS_BY_API, MODIFY_SHEET_USER, and MODIFY_SHEET_ROLE configs
- Replace sheet update permission with column-specific permission in POST /api/sheets/:id/columns
- Add initial configuration data to _Config sheet during setup
- Include CREATE_SHEET_BY_API, CREATE_SHEET_USER, CREATE_SHEET_ROLE keys
- Include MODIFY_COLUMNS_BY_API, MODIFY_SHEET_USER, MODIFY_SHEET_ROLE keys
- All new config keys default to false/empty arrays with public_read=false, public_write=false

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configuration-based permission checks for modifying spreadsheet columns, allowing for user and role restrictions.
  * Automated initial setup of configuration data in the settings sheet during sheet creation.

* **Bug Fixes**
  * Improved error handling for permission checks and configuration initialization to ensure smoother setup and clearer failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->