### PR TITLE
feat: implement GET /api/sheets/:id/columns/:columnId endpoint

### DIFF
--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -38,7 +38,8 @@ import {
   ColumnIdParamSchema,
   DeleteColumnResponseSchema,
   UpdateColumnRequestSchema,
-  UpdateColumnResponseSchema
+  UpdateColumnResponseSchema,
+  GetColumnInfoResponseSchema
 } from './api-schemas';
 
 // GET /api/roles - Get list of roles
@@ -1046,6 +1047,55 @@ export const updateColumnRoute = createRoute({
         },
       },
       description: 'Permission denied - column modification not allowed',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: NotFoundErrorSchema,
+        },
+      },
+      description: 'Sheet or column not found',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ServerErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
+// GET /api/sheets/:id/columns/:columnId - Get column schema information
+export const getColumnInfoRoute = createRoute({
+  method: 'get',
+  path: '/api/sheets/{id}/columns/{columnId}',
+  summary: 'Get column schema information',
+  description: 'Returns detailed schema information for a specific column in a sheet, including type, validation rules, and constraints. No authentication required.',
+  tags: ['Sheets'],
+  request: {
+    params: z.object({
+      id: z.string().min(1, "Sheet ID is required"),
+      columnId: z.string().min(1, "Column ID is required")
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: GetColumnInfoResponseSchema,
+        },
+      },
+      description: 'Column schema information retrieved successfully',
+    },
+    403: {
+      content: {
+        'application/json': {
+          schema: ForbiddenErrorSchema,
+        },
+      },
+      description: 'Permission denied - no read access to this sheet',
     },
     404: {
       content: {

--- a/src/api-schemas.ts
+++ b/src/api-schemas.ts
@@ -392,3 +392,24 @@ export const UpdateColumnResponseSchema = z.object({
 		message: z.string()
 	})
 });
+
+// Get column info response schema
+export const GetColumnInfoResponseSchema = z.object({
+	success: z.literal(true),
+	data: z.object({
+		sheetId: z.number(),
+		sheetName: z.string(),
+		columnName: z.string(),
+		schema: z.object({
+			type: ColumnTypeEnum,
+			required: z.boolean().optional(),
+			unique: z.boolean().optional(),
+			pattern: z.string().optional(),
+			minLength: z.number().optional(),
+			maxLength: z.number().optional(),
+			min: z.number().optional(),
+			max: z.number().optional(),
+			default: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional()
+		})
+	})
+});

--- a/src/api/sheet.ts
+++ b/src/api/sheet.ts
@@ -9,7 +9,7 @@ import {
   isTokenValid,
   type DatabaseConnection
 } from '../google-auth';
-import { getSheetsRoute, createSheetRoute, updateSheetRoute, deleteSheetRoute, getSheetMetadataRoute, addColumnsRoute, deleteColumnRoute, updateColumnRoute } from '../api-routes';
+import { getSheetsRoute, createSheetRoute, updateSheetRoute, deleteSheetRoute, getSheetMetadataRoute, addColumnsRoute, deleteColumnRoute, updateColumnRoute, getColumnInfoRoute } from '../api-routes';
 import { authenticateSession } from './auth';
 import { getMultipleConfigsFromSheet, getUserFromSheet } from '../utils/sheet-helpers';
 
@@ -2013,6 +2013,122 @@ export function registerSheetRoutes(app: OpenAPIHono<{ Bindings: Bindings }>) {
 			
 		} catch (error) {
 			console.error('Error in PUT /api/sheets/:id/columns/:columnId:', error);
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			return c.json({ success: false as false, error: errorMessage }, 500);
+		}
+	});
+
+	// GET /api/sheets/:id/columns/:columnId - Get column schema information (OpenAPI)
+	app.openapi(getColumnInfoRoute, async (c) => {
+		try {
+			const db = drizzle(c.env.DB);
+			const { id: sheetIdOrName, columnId: columnName } = c.req.valid('param');
+			
+			// Optional authentication implementation
+			const authHeader = c.req.header('authorization');
+			let userId: string | null = null;
+			let userRoles: string[] = [];
+			let isAuthenticated = false;
+			
+			// Try authentication only if authorization header is provided
+			if (authHeader) {
+				const sessionId = authHeader.replace('Bearer ', '');
+				const authResult = await authenticateSession(db, sessionId);
+				if (authResult.valid && authResult.userId) {
+					userId = authResult.userId;
+					isAuthenticated = true;
+				}
+			}
+			
+			// Get Google Sheets configuration
+			const spreadsheetId = await getConfig(db, 'spreadsheet_id');
+			if (!spreadsheetId) {
+				return c.json({ success: false as false, error: 'No spreadsheet selected' }, 500);
+			}
+			
+			// Get valid Google tokens
+			let tokens = await getGoogleTokens(db);
+			if (!tokens) {
+				return c.json({ success: false as false, error: 'No valid Google token found' }, 500);
+			}
+			
+			// Check token validity and refresh if needed
+			const isValid = await isTokenValid(db);
+			if (!isValid) {
+				const credentials = await getGoogleCredentials(db);
+				if (credentials && tokens.refresh_token) {
+					tokens = await refreshAccessToken(tokens.refresh_token, credentials);
+					await saveGoogleTokens(db, tokens);
+				} else {
+					return c.json({ success: false as false, error: 'Failed to refresh Google token' }, 500);
+				}
+			}
+			
+			// Get user information if authenticated
+			if (isAuthenticated && userId) {
+				const user = await getUserFromSheet(userId, spreadsheetId, tokens.access_token);
+				if (user) {
+					userRoles = user.roles || [];
+				}
+			}
+			
+			// Get sheet information (ID or name search)
+			const sheetInfo = await getSheetInfo(sheetIdOrName, spreadsheetId, tokens.access_token);
+			if (sheetInfo.error) {
+				if (sheetInfo.error === 'Sheet not found') {
+					return c.json({ success: false as false, error: 'Sheet not found' }, 404);
+				}
+				return c.json({ success: false as false, error: sheetInfo.error }, 500);
+			}
+			
+			const { sheetName, sheetId, columns, metadata } = sheetInfo;
+			if (!sheetName || !sheetId || !columns || !metadata) {
+				return c.json({ success: false as false, error: 'Failed to get sheet information' }, 500);
+			}
+			
+			// Check sheet read permission
+			const permissionCheck = await checkSheetReadPermission(userId, userRoles, metadata);
+			if (!permissionCheck.allowed) {
+				if (permissionCheck.error === 'Authentication required for this sheet') {
+					return c.json({ success: false as false, error: permissionCheck.error }, 401);
+				}
+				return c.json({ success: false as false, error: permissionCheck.error || 'Permission denied' }, 403);
+			}
+			
+			// Check if column exists
+			if (!columns[columnName]) {
+				return c.json({ success: false as false, error: 'Column not found' }, 404);
+			}
+			
+			// Parse column schema using schema parser
+			const { parseColumnSchema } = await import('../utils/schema-parser');
+			const columnSchema = parseColumnSchema(columns[columnName]);
+			
+			console.log('Column information retrieved successfully:', sheetIdOrName, sheetName, columnName);
+			
+			// Return success response
+			return c.json({
+				success: true as true,
+				data: {
+					sheetId: sheetId,
+					sheetName: sheetName,
+					columnName: columnName,
+					schema: {
+						type: columnSchema.type,
+						required: columnSchema.required,
+						unique: columnSchema.unique,
+						pattern: columnSchema.pattern,
+						minLength: columnSchema.minLength,
+						maxLength: columnSchema.maxLength,
+						min: columnSchema.min,
+						max: columnSchema.max,
+						default: columnSchema.default
+					}
+				}
+			});
+			
+		} catch (error) {
+			console.error('Error in GET /api/sheets/:id/columns/:columnId:', error);
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			return c.json({ success: false as false, error: errorMessage }, 500);
 		}

--- a/src/playground-html.ts
+++ b/src/playground-html.ts
@@ -392,6 +392,24 @@ export const playgroundHTML = `<!DOCTYPE html>
         <div class="section sheets-section">
             <h2>📋 列管理</h2>
             
+            <h3>列情報の取得</h3>
+            <p><strong>Note:</strong> 認証は不要です。シートの読み取り権限のみチェックされます。</p>
+            <div class="row">
+                <div class="col">
+                    <div class="form-group">
+                        <label for="getColumnSheetId">シートID:</label>
+                        <input type="text" id="getColumnSheetId" placeholder="例: 12345">
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="form-group">
+                        <label for="getColumnName">列名:</label>
+                        <input type="text" id="getColumnName" placeholder="例: user_name">
+                    </div>
+                </div>
+            </div>
+            <button onclick="getColumnInfo()">列情報取得</button>
+
             <h3>列の更新</h3>
             <p><strong>注意:</strong> 列の型（type）の変更はできません。システム列（id, created_at, updated_at等）の変更もできません。</p>
             <div class="row">
@@ -767,6 +785,44 @@ export const playgroundHTML = `<!DOCTYPE html>
         }
 
         // Column functions
+        async function getColumnInfo() {
+            try {
+                const sheetId = document.getElementById('getColumnSheetId').value.trim();
+                const columnName = document.getElementById('getColumnName').value.trim();
+                
+                if (!sheetId) {
+                    throw new Error('シートIDは必須です');
+                }
+                
+                if (!columnName) {
+                    throw new Error('列名は必須です');
+                }
+
+                // Note: This endpoint doesn't require authentication, but can use it if available
+                const token = document.getElementById('sessionToken').value.trim();
+                const headers = { 'Content-Type': 'application/json' };
+                if (token) {
+                    headers['Authorization'] = token.startsWith('Bearer ') ? token : \`Bearer \${token}\`;
+                }
+
+                const response = await fetch(\`/api/sheets/\${encodeURIComponent(sheetId)}/columns/\${encodeURIComponent(columnName)}\`, {
+                    method: 'GET',
+                    headers
+                });
+                const data = await response.json();
+                
+                showResult('columnsResult', data, !data.success);
+                
+                // Clear form on success
+                if (data.success) {
+                    document.getElementById('getColumnSheetId').value = '';
+                    document.getElementById('getColumnName').value = '';
+                }
+            } catch (error) {
+                showResult('columnsResult', { error: error.message }, true);
+            }
+        }
+
         async function updateColumn() {
             try {
                 const headers = getAuthHeaders();

--- a/src/utils/schema-parser.ts
+++ b/src/utils/schema-parser.ts
@@ -3,7 +3,7 @@
  */
 
 export interface ColumnSchema {
-  type: 'string' | 'number' | 'boolean' | 'datetime' | 'json' | 'array';
+  type: 'string' | 'number' | 'boolean' | 'datetime' | 'pointer' | 'array' | 'object';
   required?: boolean;
   unique?: boolean;
   pattern?: string;
@@ -41,11 +41,14 @@ export function parseColumnSchema(cellValue: string): ColumnSchema {
   }
 
   // Fallback to simple type string
-  const validTypes = ['string', 'number', 'boolean', 'datetime', 'json', 'array'];
+  const validTypes = ['string', 'number', 'boolean', 'datetime', 'pointer', 'array', 'object'];
   const lowerType = trimmed.toLowerCase();
   
-  if (validTypes.includes(lowerType)) {
-    return { type: lowerType as ColumnSchema['type'] };
+  // Handle backward compatibility: map 'json' to 'object'
+  const mappedType = lowerType === 'json' ? 'object' : lowerType;
+  
+  if (validTypes.includes(mappedType)) {
+    return { type: mappedType as ColumnSchema['type'] };
   }
 
   // Default to string type
@@ -127,13 +130,20 @@ export function validateValue(value: any, schema: ColumnSchema): { valid: boolea
       }
       break;
 
-    case 'json':
+    case 'object':
       if (typeof value === 'string') {
         try {
           JSON.parse(value);
         } catch (e) {
           return { valid: false, error: 'Value must be valid JSON' };
         }
+      }
+      break;
+
+    case 'pointer':
+      // Pointer type validation - should be a string representing an ID reference
+      if (typeof value !== 'string') {
+        return { valid: false, error: 'Pointer value must be a string' };
       }
       break;
 
@@ -165,6 +175,9 @@ export const SCHEMA_EXAMPLES = {
   number: { type: 'number' },
   boolean: { type: 'boolean' },
   datetime: { type: 'datetime' },
+  object: { type: 'object' },
+  pointer: { type: 'pointer' },
+  array: { type: 'array' },
   
   // Required fields
   requiredString: { type: 'string', required: true },


### PR DESCRIPTION
Implements GET /api/sheets/:id/columns/:columnId endpoint for retrieving column schema information.

## Features
- No authentication required (optional authentication supported)
- Returns complete column schema including type, validation rules, and constraints
- Supports both sheet ID and sheet name lookup
- Proper permission checking based on sheet read access
- Updated playground with testing interface
- Enhanced type compatibility in schema parser

## Implementation
- Added OpenAPI schema and route definition
- Implemented endpoint logic with comprehensive error handling
- Updated playground HTML with new testing functionality
- Enhanced schema parser for better type compatibility

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)