### PR TITLE
feat: add file upload destination settings to setup

### DIFF
--- a/docs/config-table.md
+++ b/docs/config-table.md
@@ -1,0 +1,79 @@
+# Config Table Documentation
+
+This document describes all the configuration items stored in the Config table of the Sheet DB application.
+
+## Table Structure
+
+The Config table stores key-value pairs for application configuration:
+
+- `id`: Primary key (auto-increment)
+- `name`: Configuration key (unique)
+- `value`: Configuration value (text)
+
+## Configuration Items
+
+### Google OAuth Settings
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `google_client_id` | Google OAuth 2.0 Client ID | `123456789-abcdef.apps.googleusercontent.com` |
+| `google_client_secret` | Google OAuth 2.0 Client Secret | `GOCSPX-xxxxxxxxxxxx` |
+| `google_auth_completed` | Flag indicating if Google authentication is complete | `true` or `false` |
+| `google_access_token` | Current Google access token | OAuth access token |
+| `google_refresh_token` | Google refresh token for renewing access | OAuth refresh token |
+| `google_token_expiry` | Expiry timestamp of the access token | ISO 8601 timestamp |
+
+### Auth0 Settings
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `auth0_domain` | Auth0 tenant domain | `your-tenant.auth0.com` |
+| `auth0_client_id` | Auth0 application Client ID | `xxxxxxxxxxxxxxxxxx` |
+| `auth0_client_secret` | Auth0 application Client Secret | `xxxxxxxxxxxxxxxxxx` |
+| `auth0_audience` | Auth0 API identifier (optional) | `https://api.example.com` |
+
+### Spreadsheet Settings
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `spreadsheet_id` | Google Sheets spreadsheet ID | `1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms` |
+| `spreadsheet_name` | Human-readable spreadsheet name | `My Database Sheet` |
+| `spreadsheet_url` | Full URL to the spreadsheet | `https://docs.google.com/spreadsheets/d/...` |
+| `sheets_initialized` | Flag indicating if required sheets are created | `true` or `false` |
+| `sheet_setup_status` | Current status of sheet setup process | `running`, `completed`, `error` |
+| `sheet_setup_id` | UUID for tracking sheet setup process | UUID |
+| `sheet_setup_progress` | JSON object with setup progress details | JSON string |
+
+### File Upload Settings
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `upload_destination` | Selected file upload destination | `r2` or `google_drive` |
+| `r2_bucket_name` | Cloudflare R2 bucket name | `my-bucket` |
+| `r2_access_key_id` | Cloudflare R2 Access Key ID | `xxxxxxxxxxxxxxxxxx` |
+| `r2_secret_access_key` | Cloudflare R2 Secret Access Key | `xxxxxxxxxxxxxxxxxx` |
+| `r2_account_id` | Cloudflare Account ID | `xxxxxxxxxxxxxxxxxx` |
+| `google_drive_folder_id` | Google Drive folder ID for uploads (optional) | `1A2B3C4D5E6F7G8H9I0J` |
+
+### Security Settings
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `reset_token` | Token required to reset setup configuration | Secure random string (min 16 chars) |
+| `setup_completed` | Flag indicating if initial setup is complete | `true` or `false` |
+
+## Usage Notes
+
+1. All sensitive values (tokens, secrets) should be stored securely and never exposed in logs or client responses
+2. Boolean flags are stored as string values (`"true"` or `"false"`)
+3. JSON data is stored as stringified JSON in the value field
+4. The Config table is used for application-wide settings, not user-specific data
+
+## Adding New Configuration Items
+
+When adding new configuration items:
+
+1. Update this documentation
+2. Add the key to the config array in `/src/api/setup.ts` if it needs to be loaded on the setup page
+3. Handle the configuration in the appropriate API endpoints
+4. Update the setup form UI if the setting needs to be configurable by users

--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -58,7 +58,13 @@ export function registerSetupMainRoute(app: OpenAPIHono<{ Bindings: Bindings }>)
 				'spreadsheet_url',
 				'sheets_initialized',
 				'sheet_setup_status',
-				'sheet_setup_progress'
+				'sheet_setup_progress',
+				'upload_destination',
+				'r2_bucket_name',
+				'r2_access_key_id',
+				'r2_secret_access_key',
+				'r2_account_id',
+				'google_drive_folder_id'
 			]);
 
 			// Embed configuration status into HTML
@@ -82,7 +88,14 @@ export function registerSetupMainRoute(app: OpenAPIHono<{ Bindings: Bindings }>)
 				hasSpreadsheet: !!configs.spreadsheet_id,
 				sheetsInitialized: configs.sheets_initialized === 'true',
 				sheetSetupStatus: configs.sheet_setup_status || '',
-				sheetSetupProgress: configs.sheet_setup_progress || ''
+				sheetSetupProgress: configs.sheet_setup_progress || '',
+				// File upload settings
+				uploadDestination: configs.upload_destination || '',
+				r2BucketName: configs.r2_bucket_name || '',
+				r2AccessKeyId: configs.r2_access_key_id || '',
+				r2SecretAccessKey: configs.r2_secret_access_key || '',
+				r2AccountId: configs.r2_account_id || '',
+				googleDriveFolderId: configs.google_drive_folder_id || ''
 			};
 
 			// Load template with configuration data injected
@@ -360,6 +373,32 @@ export function registerApiSetupRoute(app: OpenAPIHono<{ Bindings: Bindings }>) 
 			}
 			if (body.spreadsheetUrl) {
 				await setConfig(db, 'spreadsheet_url', body.spreadsheetUrl);
+			}
+
+			// Save file upload settings
+			if (body.uploadDestination) {
+				await setConfig(db, 'upload_destination', body.uploadDestination);
+				
+				if (body.uploadDestination === 'r2') {
+					// Save R2 settings
+					if (body.r2BucketName) {
+						await setConfig(db, 'r2_bucket_name', body.r2BucketName);
+					}
+					if (body.r2AccessKeyId) {
+						await setConfig(db, 'r2_access_key_id', body.r2AccessKeyId);
+					}
+					if (body.r2SecretAccessKey) {
+						await setConfig(db, 'r2_secret_access_key', body.r2SecretAccessKey);
+					}
+					if (body.r2AccountId) {
+						await setConfig(db, 'r2_account_id', body.r2AccountId);
+					}
+				} else if (body.uploadDestination === 'google_drive') {
+					// Save Google Drive settings
+					if (body.googleDriveFolderId) {
+						await setConfig(db, 'google_drive_folder_id', body.googleDriveFolderId);
+					}
+				}
 			}
 
 			// Set setup completion flag

--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -375,26 +375,86 @@ export function registerApiSetupRoute(app: OpenAPIHono<{ Bindings: Bindings }>) 
 				await setConfig(db, 'spreadsheet_url', body.spreadsheetUrl);
 			}
 
-			// Save file upload settings
+			// Validate and save file upload settings
 			if (body.uploadDestination) {
-				await setConfig(db, 'upload_destination', body.uploadDestination);
+				// Validate upload destination type
+				if (!['r2', 'google_drive'].includes(body.uploadDestination)) {
+					return c.json({
+						success: false,
+						error: 'Invalid upload destination. Must be either "r2" or "google_drive"'
+					}, 400);
+				}
 				
 				if (body.uploadDestination === 'r2') {
-					// Save R2 settings
-					if (body.r2BucketName) {
-						await setConfig(db, 'r2_bucket_name', body.r2BucketName);
+					// Validate R2 settings - all fields are required
+					if (!body.r2BucketName || !body.r2AccessKeyId || !body.r2SecretAccessKey || !body.r2AccountId) {
+						return c.json({
+							success: false,
+							error: 'All R2 configuration fields are required: bucket name, access key ID, secret access key, and account ID'
+						}, 400);
 					}
-					if (body.r2AccessKeyId) {
-						await setConfig(db, 'r2_access_key_id', body.r2AccessKeyId);
+					
+					// Validate R2 field formats
+					if (body.r2BucketName.length === 0 || body.r2BucketName.length > 63) {
+						return c.json({
+							success: false,
+							error: 'R2 bucket name must be between 1 and 63 characters'
+						}, 400);
 					}
-					if (body.r2SecretAccessKey) {
-						await setConfig(db, 'r2_secret_access_key', body.r2SecretAccessKey);
+					
+					// Check if the access key ID looks like a masked value
+					if (body.r2AccessKeyId.includes('•')) {
+						return c.json({
+							success: false,
+							error: 'Invalid R2 access key ID: masked values cannot be saved'
+						}, 400);
 					}
-					if (body.r2AccountId) {
-						await setConfig(db, 'r2_account_id', body.r2AccountId);
+					
+					// Check if the secret access key looks like a masked value
+					if (body.r2SecretAccessKey.includes('•')) {
+						return c.json({
+							success: false,
+							error: 'Invalid R2 secret access key: masked values cannot be saved'
+						}, 400);
 					}
+					
+					// Validate account ID format (should be alphanumeric)
+					if (!/^[a-zA-Z0-9]+$/.test(body.r2AccountId)) {
+						return c.json({
+							success: false,
+							error: 'R2 account ID must contain only alphanumeric characters'
+						}, 400);
+					}
+					
+					// Save validated R2 settings
+					await setConfig(db, 'upload_destination', body.uploadDestination);
+					await setConfig(db, 'r2_bucket_name', body.r2BucketName);
+					await setConfig(db, 'r2_access_key_id', body.r2AccessKeyId);
+					await setConfig(db, 'r2_secret_access_key', body.r2SecretAccessKey);
+					await setConfig(db, 'r2_account_id', body.r2AccountId);
+					
 				} else if (body.uploadDestination === 'google_drive') {
-					// Save Google Drive settings
+					// Validate Google Drive settings
+					if (body.googleDriveFolderId) {
+						// Validate folder ID format (should be alphanumeric with possible hyphens/underscores)
+						if (!/^[a-zA-Z0-9_-]+$/.test(body.googleDriveFolderId)) {
+							return c.json({
+								success: false,
+								error: 'Google Drive folder ID must contain only alphanumeric characters, hyphens, and underscores'
+							}, 400);
+						}
+						
+						// Typical Google Drive folder IDs are around 20-50 characters
+						if (body.googleDriveFolderId.length > 100) {
+							return c.json({
+								success: false,
+								error: 'Google Drive folder ID seems too long. Please verify the folder ID'
+							}, 400);
+						}
+					}
+					
+					// Save validated Google Drive settings
+					await setConfig(db, 'upload_destination', body.uploadDestination);
 					if (body.googleDriveFolderId) {
 						await setConfig(db, 'google_drive_folder_id', body.googleDriveFolderId);
 					}

--- a/templates/setup-form.html
+++ b/templates/setup-form.html
@@ -314,7 +314,76 @@
         </div>
         
         <div class="section">
-            <h2>5. 🔒 Security Settings</h2>
+            <h2>5. 📁 File Upload Settings</h2>
+            
+            <div id="file-upload-success" class="success-info hidden">
+                <p><strong>✅ File upload configuration completed</strong></p>
+                <p>File upload destination is already configured in the database.</p>
+            </div>
+            
+            <div id="file-upload-form">
+                <div class="info">
+                    <p>Configure where uploaded files will be stored.</p>
+                </div>
+                
+                <div class="form-group">
+                    <label for="upload-destination">Upload Destination:</label>
+                    <select id="upload-destination" style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 16px;">
+                        <option value="">Select destination</option>
+                        <option value="r2">Cloudflare R2</option>
+                        <option value="google_drive">Google Drive</option>
+                    </select>
+                    <button type="button" id="reset-upload-destination" class="reset-btn hidden">Change</button>
+                </div>
+                
+                <div id="r2-settings" class="hidden" style="margin-top: 20px;">
+                    <h3>Cloudflare R2 Settings</h3>
+                    <div class="info">
+                        <p>Configure your Cloudflare R2 bucket for file storage.</p>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="r2-bucket-name">R2 Bucket Name:</label>
+                        <input type="text" id="r2-bucket-name" placeholder="your-bucket-name">
+                        <button type="button" id="reset-r2-bucket-name" class="reset-btn hidden">Change</button>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="r2-access-key-id">R2 Access Key ID:</label>
+                        <input type="text" id="r2-access-key-id" placeholder="Your R2 Access Key ID">
+                        <button type="button" id="reset-r2-access-key-id" class="reset-btn hidden">Change</button>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="r2-secret-access-key">R2 Secret Access Key:</label>
+                        <input type="text" id="r2-secret-access-key" placeholder="Your R2 Secret Access Key">
+                        <button type="button" id="reset-r2-secret-access-key" class="reset-btn hidden">Change</button>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="r2-account-id">R2 Account ID:</label>
+                        <input type="text" id="r2-account-id" placeholder="Your Cloudflare Account ID">
+                        <button type="button" id="reset-r2-account-id" class="reset-btn hidden">Change</button>
+                    </div>
+                </div>
+                
+                <div id="google-drive-settings" class="hidden" style="margin-top: 20px;">
+                    <h3>Google Drive Settings</h3>
+                    <div class="info">
+                        <p>Files will be uploaded to Google Drive using the same Google account connected above.</p>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="google-drive-folder-id">Google Drive Folder ID (Optional):</label>
+                        <input type="text" id="google-drive-folder-id" placeholder="Leave empty to use root folder">
+                        <button type="button" id="reset-google-drive-folder-id" class="reset-btn hidden">Change</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="section">
+            <h2>6. 🔒 Security Settings</h2>
             <div class="info">
                 <p>Set the token required to reset the setup.</p>
                 <p><strong>⚠️ Important:</strong> Please store this token in a secure location. If lost, you will not be able to reset the configuration.</p>
@@ -335,7 +404,7 @@
         </div>
         
         <div class="section">
-            <h2>6. 🔐 Auth0 Authentication Test</h2>
+            <h2>7. 🔐 Auth0 Authentication Test</h2>
             
             <div id="auth0-test-not-ready" class="info">
                 <p>After completing Auth0 configuration and spreadsheet settings, you can test authentication.</p>
@@ -459,6 +528,63 @@
                 document.getElementById('reset-token').classList.add('readonly-field');
             }
             
+            // If file upload configuration already exists
+            if (config.uploadDestination) {
+                // Show success message
+                document.getElementById('file-upload-success').classList.remove('hidden');
+                
+                // Set upload destination
+                const uploadDestField = document.getElementById('upload-destination');
+                uploadDestField.value = config.uploadDestination;
+                uploadDestField.readOnly = true;
+                uploadDestField.classList.add('readonly-field');
+                document.getElementById('reset-upload-destination').classList.remove('hidden');
+                
+                // Trigger change event to show relevant settings
+                uploadDestField.dispatchEvent(new Event('change'));
+                
+                // Set R2 settings if applicable
+                if (config.uploadDestination === 'r2') {
+                    if (config.r2BucketName) {
+                        const bucketField = document.getElementById('r2-bucket-name');
+                        bucketField.value = config.r2BucketName;
+                        bucketField.readOnly = true;
+                        bucketField.classList.add('readonly-field');
+                        document.getElementById('reset-r2-bucket-name').classList.remove('hidden');
+                    }
+                    if (config.r2AccessKeyId) {
+                        const accessKeyField = document.getElementById('r2-access-key-id');
+                        accessKeyField.value = maskClientId(config.r2AccessKeyId);
+                        accessKeyField.readOnly = true;
+                        accessKeyField.classList.add('readonly-field');
+                        document.getElementById('reset-r2-access-key-id').classList.remove('hidden');
+                    }
+                    if (config.r2SecretAccessKey) {
+                        const secretKeyField = document.getElementById('r2-secret-access-key');
+                        secretKeyField.value = '••••••••••••••••••••••••••••••••';
+                        secretKeyField.readOnly = true;
+                        secretKeyField.classList.add('readonly-field');
+                        document.getElementById('reset-r2-secret-access-key').classList.remove('hidden');
+                    }
+                    if (config.r2AccountId) {
+                        const accountIdField = document.getElementById('r2-account-id');
+                        accountIdField.value = config.r2AccountId;
+                        accountIdField.readOnly = true;
+                        accountIdField.classList.add('readonly-field');
+                        document.getElementById('reset-r2-account-id').classList.remove('hidden');
+                    }
+                }
+                
+                // Set Google Drive settings if applicable
+                if (config.uploadDestination === 'google_drive' && config.googleDriveFolderId) {
+                    const folderIdField = document.getElementById('google-drive-folder-id');
+                    folderIdField.value = config.googleDriveFolderId;
+                    folderIdField.readOnly = true;
+                    folderIdField.classList.add('readonly-field');
+                    document.getElementById('reset-google-drive-folder-id').classList.remove('hidden');
+                }
+            }
+            
             // If connected=true parameter exists (after authentication completion)
             if (config.connected) {
                 // Show additional success message
@@ -546,6 +672,41 @@
             document.getElementById('auth0-success').classList.add('hidden');
         }
         
+        function resetFileUploadConfig() {
+            // Reset all file upload fields
+            const fileUploadFields = [
+                'upload-destination',
+                'r2-bucket-name',
+                'r2-access-key-id',
+                'r2-secret-access-key',
+                'r2-account-id',
+                'google-drive-folder-id'
+            ];
+            
+            fileUploadFields.forEach(fieldId => {
+                const field = document.getElementById(fieldId);
+                if (fieldId === 'upload-destination') {
+                    field.value = '';
+                    // Trigger change event to hide settings
+                    field.dispatchEvent(new Event('change'));
+                } else {
+                    field.value = '';
+                }
+                field.readOnly = false;
+                field.classList.remove('readonly-field');
+                
+                // Hide corresponding reset button
+                const resetBtn = document.getElementById('reset-' + fieldId);
+                if (resetBtn) {
+                    resetBtn.classList.add('hidden');
+                }
+            });
+            
+            // Hide success message and show form
+            document.getElementById('file-upload-success').classList.add('hidden');
+            document.getElementById('file-upload-form').classList.remove('hidden');
+        }
+        
         // Token generation function
         function generateSecureToken() {
             const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
@@ -573,6 +734,32 @@
                 const tokenField = document.getElementById('reset-token');
                 tokenField.value = generateSecureToken();
             });
+            
+            // File upload destination change event
+            document.getElementById('upload-destination').addEventListener('change', function(e) {
+                const value = e.target.value;
+                const r2Settings = document.getElementById('r2-settings');
+                const googleDriveSettings = document.getElementById('google-drive-settings');
+                
+                // Hide all settings first
+                r2Settings.classList.add('hidden');
+                googleDriveSettings.classList.add('hidden');
+                
+                // Show relevant settings
+                if (value === 'r2') {
+                    r2Settings.classList.remove('hidden');
+                } else if (value === 'google_drive') {
+                    googleDriveSettings.classList.remove('hidden');
+                }
+            });
+            
+            // File upload reset button event listeners
+            document.getElementById('reset-upload-destination').addEventListener('click', resetFileUploadConfig);
+            document.getElementById('reset-r2-bucket-name').addEventListener('click', resetFileUploadConfig);
+            document.getElementById('reset-r2-access-key-id').addEventListener('click', resetFileUploadConfig);
+            document.getElementById('reset-r2-secret-access-key').addEventListener('click', resetFileUploadConfig);
+            document.getElementById('reset-r2-account-id').addEventListener('click', resetFileUploadConfig);
+            document.getElementById('reset-google-drive-folder-id').addEventListener('click', resetFileUploadConfig);
         });
         
         function connectToGoogle() {
@@ -908,6 +1095,43 @@
                 configData.spreadsheetId = selectedSheet.id;
                 configData.spreadsheetName = selectedSheet.name;
                 configData.spreadsheetUrl = selectedSheet.url;
+            }
+            
+            // Process file upload settings
+            const uploadDestination = document.getElementById('upload-destination').value;
+            if (uploadDestination) {
+                configData.uploadDestination = uploadDestination;
+                
+                if (uploadDestination === 'r2') {
+                    // R2 settings
+                    const r2BucketName = document.getElementById('r2-bucket-name').value;
+                    const r2AccessKeyId = document.getElementById('r2-access-key-id').value;
+                    const r2SecretAccessKey = document.getElementById('r2-secret-access-key').value;
+                    const r2AccountId = document.getElementById('r2-account-id').value;
+                    
+                    if (!r2BucketName || !r2AccessKeyId || !r2SecretAccessKey || !r2AccountId) {
+                        alert('Please fill in all R2 configuration fields.');
+                        return;
+                    }
+                    
+                    configData.r2BucketName = r2BucketName;
+                    
+                    // Only send non-masked values
+                    if (!r2AccessKeyId.includes('•')) {
+                        configData.r2AccessKeyId = r2AccessKeyId;
+                    }
+                    if (!r2SecretAccessKey.includes('•')) {
+                        configData.r2SecretAccessKey = r2SecretAccessKey;
+                    }
+                    configData.r2AccountId = r2AccountId;
+                    
+                } else if (uploadDestination === 'google_drive') {
+                    // Google Drive settings
+                    const googleDriveFolderId = document.getElementById('google-drive-folder-id').value;
+                    if (googleDriveFolderId) {
+                        configData.googleDriveFolderId = googleDriveFolderId;
+                    }
+                }
             }
             
             // Debug: Output data being sent to console


### PR DESCRIPTION
- Add file upload destination configuration UI in setup form
- Support R2 and Google Drive as upload destinations
- Add configuration fields for R2 (bucket name, access keys, account ID)
- Add configuration field for Google Drive (folder ID)
- Save file upload settings to Config table
- Create documentation for Config table items
- Update setup form to display saved file upload configurations

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "File Upload Settings" section to the setup form, enabling configuration of file upload destinations (Cloudflare R2 or Google Drive) with credential input and reset functionality.
* **Documentation**
  * Added a new document describing the Config table structure and configuration keys, including file upload settings.
* **Style**
  * Updated section numbering in the setup form to integrate the new file upload settings section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->