### PR TITLE
feat: add configurable session expiration time

### DIFF
--- a/docs/config-table.md
+++ b/docs/config-table.md
@@ -66,6 +66,7 @@ The Config table stores key-value pairs for application configuration:
 |-----|-------------|---------|
 | `reset_token` | Token required to reset setup configuration | Secure random string (min 16 chars) |
 | `setup_completed` | Flag indicating if initial setup is complete | `true` or `false` |
+| `session_expired_seconds` | Session expiration time in seconds | `604800` (1 week, default) |
 
 ## Usage Notes
 

--- a/docs/config-table.md
+++ b/docs/config-table.md
@@ -66,7 +66,7 @@ The Config table stores key-value pairs for application configuration:
 |-----|-------------|---------|
 | `reset_token` | Token required to reset setup configuration | Secure random string (min 16 chars) |
 | `setup_completed` | Flag indicating if initial setup is complete | `true` or `false` |
-| `session_expired_seconds` | Session expiration time in seconds | `604800` (1 week, default) |
+| `session_expired_seconds` | Session expiration time in seconds (range: 60-2592000) | `3600` (1 hour, default) |
 
 ## Usage Notes
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -7,6 +7,7 @@ import {
 	getGoogleCredentials, 
 	refreshAccessToken, 
 	saveGoogleTokens,
+	CONFIG_KEYS,
 	type DatabaseConnection
 } from '../google-auth';
 import { authStartRoute, authCallbackGetRoute, authCallbackPostRoute } from '../api-routes';
@@ -411,9 +412,11 @@ async function saveSessionToSheet(db: DatabaseConnection, sessionId: string, use
 			throw new Error('No valid Google token found');
 		}
 		
-		// 現在の日時と有効期限（1時間後）
+		// 現在の日時と有効期限（設定可能）
 		const now = new Date();
-		const expiresAt = new Date(now.getTime() + 60 * 60 * 1000); // 1時間後
+		const sessionExpiredSeconds = await getConfig(db, CONFIG_KEYS.SESSION_EXPIRED_SECONDS);
+		const expiredSeconds = sessionExpiredSeconds ? parseInt(sessionExpiredSeconds) : 604800; // デフォルト: 1週間
+		const expiresAt = new Date(now.getTime() + expiredSeconds * 1000);
 		
 		// セッションデータを準備
 		const sessionData = [

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -415,7 +415,14 @@ async function saveSessionToSheet(db: DatabaseConnection, sessionId: string, use
 		// 現在の日時と有効期限（設定可能）
 		const now = new Date();
 		const sessionExpiredSeconds = await getConfig(db, CONFIG_KEYS.SESSION_EXPIRED_SECONDS);
-		const expiredSeconds = sessionExpiredSeconds ? parseInt(sessionExpiredSeconds) : 604800; // デフォルト: 1週間
+		let expiredSeconds = sessionExpiredSeconds ? parseInt(sessionExpiredSeconds, 10) : 3600; // デフォルト: 1時間
+		
+		// セッション有効期限の検証（1分〜30日の範囲）
+		if (isNaN(expiredSeconds) || expiredSeconds < 60 || expiredSeconds > 2592000) {
+			console.warn('Invalid session expiration time:', sessionExpiredSeconds, 'using default 3600 seconds');
+			expiredSeconds = 3600; // デフォルト: 1時間
+		}
+		
 		const expiresAt = new Date(now.getTime() + expiredSeconds * 1000);
 		
 		// セッションデータを準備

--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -64,7 +64,8 @@ export function registerSetupMainRoute(app: OpenAPIHono<{ Bindings: Bindings }>)
 				'r2_access_key_id',
 				'r2_secret_access_key',
 				'r2_account_id',
-				'google_drive_folder_id'
+				'google_drive_folder_id',
+				'session_expired_seconds'
 			]);
 
 			// Embed configuration status into HTML
@@ -95,7 +96,9 @@ export function registerSetupMainRoute(app: OpenAPIHono<{ Bindings: Bindings }>)
 				r2AccessKeyId: configs.r2_access_key_id || '',
 				r2SecretAccessKey: configs.r2_secret_access_key || '',
 				r2AccountId: configs.r2_account_id || '',
-				googleDriveFolderId: configs.google_drive_folder_id || ''
+				googleDriveFolderId: configs.google_drive_folder_id || '',
+				// Session settings
+				sessionExpiredSeconds: configs.session_expired_seconds || '604800' // Default: 1 week
 			};
 
 			// Load template with configuration data injected

--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -98,7 +98,7 @@ export function registerSetupMainRoute(app: OpenAPIHono<{ Bindings: Bindings }>)
 				r2AccountId: configs.r2_account_id || '',
 				googleDriveFolderId: configs.google_drive_folder_id || '',
 				// Session settings
-				sessionExpiredSeconds: configs.session_expired_seconds || '604800' // Default: 1 week
+				sessionExpiredSeconds: configs.session_expired_seconds || '3600' // Default: 1 hour
 			};
 
 			// Load template with configuration data injected

--- a/src/google-auth.ts
+++ b/src/google-auth.ts
@@ -28,6 +28,7 @@ export const CONFIG_KEYS = {
   GOOGLE_TOKEN_EXPIRES_AT: 'google_token_expires_at',
   GOOGLE_TOKEN_SCOPE: 'google_token_scope',
   SETUP_COMPLETED: 'setup_completed',
+  SESSION_EXPIRED_SECONDS: 'session_expired_seconds',
 } as const;
 
 /**


### PR DESCRIPTION
This PR implements configurable session expiration time as requested in issue #43.

## Changes
- Add SESSION_EXPIRED_SECONDS configuration key (default: 604800 seconds = 1 week)
- Modify session creation in auth.ts to use configurable expiration
- Update setup.ts to load session expiration configuration
- Add documentation for session_expired_seconds in config-table.md
- Replace hardcoded 1-hour session expiration with configurable value

Fixes #43

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring session expiration duration, allowing users to set how long sessions remain active.
* **Documentation**
  * Updated documentation to include the new `session_expired_seconds` configuration option in the Security Settings section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->