### PR TITLE
feat: implement DELETE /users/me endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,70 @@ Content-Type: application/json
 }
 ```
 
+### User Management APIs
+
+#### Get Current User Information
+**GET** `/api/users/me`
+
+Retrieves the authenticated user's information from the _User sheet.
+
+**Authentication:** Required
+
+**Example Request:**
+```bash
+GET /api/users/me
+Authorization: Bearer <session-token>
+```
+
+**Example Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "auth0|user123",
+    "name": "John Doe",
+    "email": "john@example.com",
+    "given_name": "John",
+    "family_name": "Doe",
+    "picture": "https://example.com/avatar.jpg",
+    "email_verified": true,
+    "locale": "en",
+    "roles": ["user"],
+    "created_at": "2023-01-01T12:00:00Z",
+    "updated_at": "2023-01-01T12:00:00Z"
+  }
+}
+```
+
+#### Delete Current User Account
+**DELETE** `/api/users/me`
+
+Deletes the authenticated user's own data from the _User sheet. The user can only delete their own account. Data is cleared rather than deleted to prevent row shifting conflicts.
+
+**Authentication:** Required
+
+**Example Request:**
+```bash
+DELETE /api/users/me
+Authorization: Bearer <session-token>
+```
+
+**Example Response:**
+```json
+{
+  "success": true,
+  "message": "User account has been successfully deleted"
+}
+```
+
+**Error Response:**
+```json
+{
+  "success": false,
+  "error": "User not found in _User sheet"
+}
+```
+
 ### Permission System
 
 Sheet access is controlled by the following fields in the sheet metadata:

--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -487,6 +487,55 @@ export const getUserMeRoute = createRoute({
   },
 });
 
+// DELETE /api/users/me - Delete current authenticated user
+export const deleteUserMeRoute = createRoute({
+  method: 'delete',
+  path: '/api/users/me',
+  summary: 'Delete current user',
+  description: 'Deletes the authenticated user\'s own data from the _User sheet. Data is cleared rather than deleted to prevent row shifting conflicts.',
+  tags: ['Users'],
+  security: [{ BearerAuth: [] }],
+  request: {
+    headers: z.object({
+      authorization: z.string().regex(/^Bearer .+/, "Must be in format 'Bearer <token>'")
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: DeleteUserResponseSchema,
+        },
+      },
+      description: 'User deleted successfully',
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: UnauthorizedErrorSchema,
+        },
+      },
+      description: 'Authentication failed',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: NotFoundErrorSchema,
+        },
+      },
+      description: 'User not found in _User sheet',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ServerErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
 // PUT /api/users/:id - Update user information
 export const updateUserRoute = createRoute({
   method: 'put',

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -19,6 +19,111 @@ type Bindings = {
 };
 
 
+// Helper function for user deletion from Google Sheets
+async function deleteUserFromSheet(
+	targetUserId: string,
+	spreadsheetId: string,
+	accessToken: string,
+	options: {
+		requirePermissionCheck?: boolean;
+		currentUserId?: string;
+		currentUserRoles?: string[];
+	} = {}
+): Promise<{ success: boolean; error?: string; message?: string }> {
+	try {
+		// Check if target user exists
+		const targetUser = await getUserFromSheet(targetUserId, spreadsheetId, accessToken);
+		if (!targetUser) {
+			return { success: false, error: 'Target user not found' };
+		}
+
+		// Perform permission check if required
+		if (options.requirePermissionCheck && options.currentUserId && options.currentUserRoles) {
+			const hasPermission = await checkUserWritePermission(
+				options.currentUserId,
+				targetUserId,
+				options.currentUserRoles,
+				spreadsheetId,
+				accessToken
+			);
+			
+			if (!hasPermission) {
+				return { 
+					success: false, 
+					error: 'Permission denied - no write access to this user' 
+				};
+			}
+		}
+
+		// Get current user data to find row position
+		const userResponse = await fetch(
+			`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A:Q`,
+			{
+				headers: {
+					'Authorization': `Bearer ${accessToken}`,
+					'Content-Type': 'application/json',
+				}
+			}
+		);
+		
+		if (!userResponse.ok) {
+			return { success: false, error: 'Failed to fetch user data' };
+		}
+		
+		const userData = await userResponse.json() as any;
+		const users = userData.values || [];
+		
+		// Search for user (from row 3)
+		const userRowIndex = users.findIndex((row: string[], index: number) => 
+			index >= 2 && row[0] === targetUserId
+		);
+		
+		if (userRowIndex === -1) {
+			return { success: false, error: 'User not found in _User sheet' };
+		}
+		
+		const targetRowNumber = userRowIndex + 1; // Convert to sheet row number
+		
+		// Clear user data to prevent row shifting conflicts
+		// Create empty data array matching the header row length
+		const headerRow = users[0] || [];
+		const emptyData = new Array(headerRow.length).fill('');
+		
+		// Clear the user data (keep the row but clear all data)
+		const clearResponse = await fetch(
+			`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A${targetRowNumber}:Q${targetRowNumber}?valueInputOption=RAW`,
+			{
+				method: 'PUT',
+				headers: {
+					'Authorization': `Bearer ${accessToken}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					values: [emptyData]
+				})
+			}
+		);
+		
+		if (!clearResponse.ok) {
+			const errorText = await clearResponse.text();
+			console.error('Failed to clear user data:', clearResponse.status, errorText);
+			return { success: false, error: `Failed to delete user: ${clearResponse.status}` };
+		}
+		
+		console.log('User data cleared successfully:', targetUserId);
+		
+		return {
+			success: true,
+			message: `User '${targetUserId}' has been successfully deleted`
+		};
+		
+	} catch (error) {
+		console.error('Error in deleteUserFromSheet:', error);
+		const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+		return { success: false, error: errorMessage };
+	}
+}
+
 // Helper function for permission checking
 async function checkUserWritePermission(
 	currentUserId: string,
@@ -539,88 +644,27 @@ export function registerUserRoutes(app: OpenAPIHono<{ Bindings: Bindings }>) {
 				return c.json({ success: false as false, error: 'Current user not found' }, 401);
 			}
 			
-			// Check target user existence
-			const targetUser = await getUserFromSheet(targetUserId, spreadsheetId, tokens.access_token);
-			if (!targetUser) {
-				return c.json({ success: false as false, error: 'Target user not found' }, 404);
-			}
-			
-			// Permission check
-			const hasPermission = await checkUserWritePermission(
-				currentUserId,
+			// Use helper function to delete user with permission check
+			const deleteResult = await deleteUserFromSheet(
 				targetUserId,
-				currentUser.roles || [],
 				spreadsheetId,
-				tokens.access_token
-			);
-			
-			if (!hasPermission) {
-				return c.json({ 
-					success: false as false, 
-					error: 'Permission denied - no write access to this user' 
-				}, 403);
-			}
-			
-			// 現在のユーザーデータを取得して行位置を特定
-			const userResponse = await fetch(
-				`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A:Q`,
+				tokens.access_token,
 				{
-					headers: {
-						'Authorization': `Bearer ${tokens.access_token}`,
-						'Content-Type': 'application/json',
-					}
+					requirePermissionCheck: true,
+					currentUserId,
+					currentUserRoles: currentUser.roles || []
 				}
 			);
 			
-			if (!userResponse.ok) {
-				return c.json({ success: false as false, error: 'Failed to fetch user data' }, 500);
+			if (!deleteResult.success) {
+				const statusCode = deleteResult.error?.includes('Permission denied') ? 403 :
+								 deleteResult.error?.includes('not found') ? 404 : 500;
+				return c.json({ success: false as false, error: deleteResult.error }, statusCode);
 			}
-			
-			const userData = await userResponse.json() as any;
-			const users = userData.values || [];
-			
-			// Search for user (from row 3)
-			const userRowIndex = users.findIndex((row: string[], index: number) => 
-				index >= 2 && row[0] === targetUserId
-			);
-			
-			if (userRowIndex === -1) {
-				return c.json({ success: false as false, error: 'User not found' }, 404);
-			}
-			
-			const targetRowNumber = userRowIndex + 1; // Convert to sheet row number
-			
-			// コンフリクト防止のため、行削除ではなくデータクリアを実行
-			// 全列を空文字で上書きする（ヘッダー行の列数に合わせる）
-			const headerRow = users[0] || [];
-			const emptyData = new Array(headerRow.length).fill('');
-			
-			// データをクリア（行は残す）
-			const clearResponse = await fetch(
-				`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A${targetRowNumber}:Q${targetRowNumber}?valueInputOption=RAW`,
-				{
-					method: 'PUT',
-					headers: {
-						'Authorization': `Bearer ${tokens.access_token}`,
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify({
-						values: [emptyData]
-					})
-				}
-			);
-			
-			if (!clearResponse.ok) {
-				const errorText = await clearResponse.text();
-				console.error('Failed to clear user data:', clearResponse.status, errorText);
-				return c.json({ success: false as false, error: `Failed to delete user: ${clearResponse.status}` }, 500);
-			}
-			
-			console.log('User data cleared successfully:', targetUserId);
 			
 			return c.json({
 				success: true as true,
-				message: `User '${targetUserId}' has been successfully deleted`
+				message: deleteResult.message || `User '${targetUserId}' has been successfully deleted`
 			});
 			
 		} catch (error) {
@@ -674,68 +718,20 @@ export function registerUserRoutes(app: OpenAPIHono<{ Bindings: Bindings }>) {
 				}
 			}
 			
-			// Check if user exists in _User sheet
-			const targetUser = await getUserFromSheet(currentUserId, spreadsheetId, tokens.access_token);
-			if (!targetUser) {
-				return c.json({ success: false as false, error: 'User not found in _User sheet' }, 404);
-			}
-			
-			// Get current user data to find row position
-			const userResponse = await fetch(
-				`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A:Q`,
+			// Use helper function to delete current user (no permission check needed)
+			const deleteResult = await deleteUserFromSheet(
+				currentUserId,
+				spreadsheetId,
+				tokens.access_token,
 				{
-					headers: {
-						'Authorization': `Bearer ${tokens.access_token}`,
-						'Content-Type': 'application/json',
-					}
+					requirePermissionCheck: false
 				}
 			);
 			
-			if (!userResponse.ok) {
-				return c.json({ success: false as false, error: 'Failed to fetch user data' }, 500);
+			if (!deleteResult.success) {
+				const statusCode = deleteResult.error?.includes('not found') ? 404 : 500;
+				return c.json({ success: false as false, error: deleteResult.error }, statusCode);
 			}
-			
-			const userData = await userResponse.json() as any;
-			const users = userData.values || [];
-			
-			// Search for user (from row 3)
-			const userRowIndex = users.findIndex((row: string[], index: number) => 
-				index >= 2 && row[0] === currentUserId
-			);
-			
-			if (userRowIndex === -1) {
-				return c.json({ success: false as false, error: 'User not found in _User sheet' }, 404);
-			}
-			
-			const targetRowNumber = userRowIndex + 1; // Convert to sheet row number
-			
-			// Clear user data to prevent row shifting conflicts
-			// Create empty data array matching the header row length
-			const headerRow = users[0] || [];
-			const emptyData = new Array(headerRow.length).fill('');
-			
-			// Clear the user data (keep the row but clear all data)
-			const clearResponse = await fetch(
-				`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A${targetRowNumber}:Q${targetRowNumber}?valueInputOption=RAW`,
-				{
-					method: 'PUT',
-					headers: {
-						'Authorization': `Bearer ${tokens.access_token}`,
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify({
-						values: [emptyData]
-					})
-				}
-			);
-			
-			if (!clearResponse.ok) {
-				const errorText = await clearResponse.text();
-				console.error('Failed to clear user data:', clearResponse.status, errorText);
-				return c.json({ success: false as false, error: `Failed to delete user: ${clearResponse.status}` }, 500);
-			}
-			
-			console.log('User data cleared successfully:', currentUserId);
 			
 			return c.json({
 				success: true as true,

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -8,7 +8,7 @@ import {
   refreshAccessToken,
   isTokenValid
 } from '../google-auth';
-import { getUserMeRoute, updateUserRoute, deleteUserRoute } from '../api-routes';
+import { getUserMeRoute, updateUserRoute, deleteUserRoute, deleteUserMeRoute } from '../api-routes';
 import { authenticateSession } from './auth';
 import { getUserFromSheet } from '../utils/sheet-helpers';
 import { parseColumnSchema, validateValue } from '../utils/schema-parser';
@@ -625,6 +625,125 @@ export function registerUserRoutes(app: OpenAPIHono<{ Bindings: Bindings }>) {
 			
 		} catch (error) {
 			console.error('Error in DELETE /api/users/:id:', error);
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			return c.json({ success: false as false, error: errorMessage }, 500);
+		}
+	});
+
+	// DELETE /api/users/me - Delete current authenticated user
+	app.openapi(deleteUserMeRoute, async (c) => {
+		try {
+			const db = drizzle(c.env.DB);
+			
+			// Get session ID from authentication header
+			const authHeader = c.req.valid('header').authorization;
+			const sessionId = authHeader.replace('Bearer ', '');
+			
+			// Session authentication
+			const authResult = await authenticateSession(db, sessionId);
+			if (!authResult.valid) {
+				return c.json({ success: false as false, error: authResult.error || 'Authentication failed' }, 401);
+			}
+			
+			const currentUserId = authResult.userId;
+			if (!currentUserId) {
+				return c.json({ success: false as false, error: 'User ID not found in session' }, 401);
+			}
+			
+			// Get Google Sheets settings
+			const spreadsheetId = await getConfig(db, 'spreadsheet_id');
+			if (!spreadsheetId) {
+				return c.json({ success: false as false, error: 'No spreadsheet selected' }, 500);
+			}
+			
+			// Get valid Google token
+			let tokens = await getGoogleTokens(db);
+			if (!tokens) {
+				return c.json({ success: false as false, error: 'No valid Google token found' }, 500);
+			}
+			
+			// Check token validity and refresh if necessary
+			const isValid = await isTokenValid(db);
+			if (!isValid) {
+				const credentials = await getGoogleCredentials(db);
+				if (credentials && tokens.refresh_token) {
+					tokens = await refreshAccessToken(tokens.refresh_token, credentials);
+					await saveGoogleTokens(db, tokens);
+				} else {
+					return c.json({ success: false as false, error: 'Failed to refresh Google token' }, 500);
+				}
+			}
+			
+			// Check if user exists in _User sheet
+			const targetUser = await getUserFromSheet(currentUserId, spreadsheetId, tokens.access_token);
+			if (!targetUser) {
+				return c.json({ success: false as false, error: 'User not found in _User sheet' }, 404);
+			}
+			
+			// Get current user data to find row position
+			const userResponse = await fetch(
+				`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A:Q`,
+				{
+					headers: {
+						'Authorization': `Bearer ${tokens.access_token}`,
+						'Content-Type': 'application/json',
+					}
+				}
+			);
+			
+			if (!userResponse.ok) {
+				return c.json({ success: false as false, error: 'Failed to fetch user data' }, 500);
+			}
+			
+			const userData = await userResponse.json() as any;
+			const users = userData.values || [];
+			
+			// Search for user (from row 3)
+			const userRowIndex = users.findIndex((row: string[], index: number) => 
+				index >= 2 && row[0] === currentUserId
+			);
+			
+			if (userRowIndex === -1) {
+				return c.json({ success: false as false, error: 'User not found in _User sheet' }, 404);
+			}
+			
+			const targetRowNumber = userRowIndex + 1; // Convert to sheet row number
+			
+			// Clear user data to prevent row shifting conflicts
+			// Create empty data array matching the header row length
+			const headerRow = users[0] || [];
+			const emptyData = new Array(headerRow.length).fill('');
+			
+			// Clear the user data (keep the row but clear all data)
+			const clearResponse = await fetch(
+				`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/_User!A${targetRowNumber}:Q${targetRowNumber}?valueInputOption=RAW`,
+				{
+					method: 'PUT',
+					headers: {
+						'Authorization': `Bearer ${tokens.access_token}`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						values: [emptyData]
+					})
+				}
+			);
+			
+			if (!clearResponse.ok) {
+				const errorText = await clearResponse.text();
+				console.error('Failed to clear user data:', clearResponse.status, errorText);
+				return c.json({ success: false as false, error: `Failed to delete user: ${clearResponse.status}` }, 500);
+			}
+			
+			console.log('User data cleared successfully:', currentUserId);
+			
+			return c.json({
+				success: true as true,
+				message: 'User account has been successfully deleted'
+			});
+			
+		} catch (error) {
+			console.error('Error in DELETE /api/users/me:', error);
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			return c.json({ success: false as false, error: errorMessage }, 500);
 		}


### PR DESCRIPTION
Implements DELETE /api/users/me endpoint for user self-deletion as requested in issue #49.

## Changes
- Add DELETE /api/users/me endpoint with authentication
- Clear user data instead of deleting row to prevent conflicts
- Update README.md with User Management APIs documentation
- Follow existing code patterns and error handling

## Requirements Met
- ✅ Authentication required
- ✅ Self-deletion from _User sheet
- ✅ Returns {success: true} on success
- ✅ Clear data row instead of delete for conflict prevention
- ✅ All code and documentation in English
- ✅ API documentation updated
- ✅ OpenAPI spec updated

Closes #49

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint allowing authenticated users to delete their own account data via a DELETE request to `/api/users/me`.
  * Added an endpoint to retrieve the current authenticated user's profile information via a GET request to `/api/users/me`.

* **Documentation**
  * Updated the README with a "User Management APIs" section, detailing the new endpoints for retrieving and deleting the authenticated user's information, including example requests and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->