### PR TITLE
refactor: separate Config table and _Config sheet usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,15 @@ Sheet DB is a Backend-as-a-Service (BaaS) application that uses Google Sheets as
 ## Key Components
 
 ### Database Schema
-- **Config**: Application configuration storage
+- **Config**: Infrastructure and setup configuration storage (D1 database)
+- **_Config Sheet**: Runtime operational settings (Google Sheets)
 - **Cache**: 10-minute TTL cache for Google Sheets data
 - **Queue**: Background processing queue for CRUD operations
 - **Session**: User session management
+
+### Configuration Architecture
+- **Config Table (D1)**: Infrastructure settings (Google OAuth, Auth0, spreadsheet IDs, file upload destinations, credentials)
+- **_Config Sheet**: Runtime settings (API permissions, user/role access controls, file upload policies)
 
 ### Data Flow
 1. **Read Operations**: Cached in D1, background refresh every 10 minutes

--- a/docs/config-table.md
+++ b/docs/config-table.md
@@ -1,6 +1,16 @@
-# Config Table Documentation
+# Configuration Documentation
 
-This document describes all the configuration items stored in the Config table of the Sheet DB application.
+This document describes the configuration system used in Sheet DB, which consists of two storage locations: the Config table (D1 database) and the _Config sheet (Google Sheets).
+
+## Configuration Architecture
+
+### Config Table (D1 Database)
+Used for **infrastructure and setup configurations** that are set during initial application setup and rarely changed during runtime.
+
+### _Config Sheet (Google Sheets)
+Used for **runtime operational settings** that can be modified by users during normal application operation.
+
+## Config Table (Infrastructure Settings)
 
 ## Table Structure
 
@@ -44,20 +54,17 @@ The Config table stores key-value pairs for application configuration:
 | `sheet_setup_id` | UUID for tracking sheet setup process | UUID |
 | `sheet_setup_progress` | JSON object with setup progress details | JSON string |
 
-### File Upload Settings
+### File Upload Infrastructure Settings
 
 | Key | Description | Example |
 |-----|-------------|---------|
 | `upload_destination` | Selected file upload destination | `Google Drive` or `R2` |
-| `ANONYMOUS_FILE_UPLOAD` | Allow uploads without authentication | `true` or `false` |
-| `MAX_FILE_SIZE` | Maximum file size in bytes | `10485760` (10MB) |
 | `ALLOW_UPLOAD_EXTENSION` | Allowed file extensions/types | `image/*` or `*.jpg,*.png` |
-| `FILE_UPLOAD_PUBLIC` | Make uploaded files publicly accessible | `true` or `false` |
 | `r2_bucket_name` | Cloudflare R2 bucket name | `my-bucket` |
 | `r2_access_key_id` | Cloudflare R2 Access Key ID | `xxxxxxxxxxxxxxxxxx` |
 | `r2_secret_access_key` | Cloudflare R2 Secret Access Key | `xxxxxxxxxxxxxxxxxx` |
 | `r2_account_id` | Cloudflare Account ID | `xxxxxxxxxxxxxxxxxx` |
-| `R2_PUBLIC_URL` | Base URL for R2 public file access | `https://your-r2-domain.com` |
+| `r2_public_url` | Base URL for R2 public file access (lowercase) | `https://your-r2-domain.com` |
 | `google_drive_folder_id` | Google Drive folder ID for uploads (optional) | `1A2B3C4D5E6F7G8H9I0J` |
 
 ### Security Settings
@@ -68,18 +75,51 @@ The Config table stores key-value pairs for application configuration:
 | `setup_completed` | Flag indicating if initial setup is complete | `true` or `false` |
 | `session_expired_seconds` | Session expiration time in seconds (range: 60-2592000) | `3600` (1 hour, default) |
 
+## _Config Sheet (Runtime Settings)
+
+The _Config sheet stores runtime operational settings that can be modified during normal application operation:
+
+### Sheet Management Settings
+
+| Key | Description | Default Value |
+|-----|-------------|---------------|
+| `CREATE_SHEET_BY_API` | Allow sheet creation via API | `false` |
+| `CREATE_SHEET_USER` | Array of user IDs allowed to create sheets | `[]` |
+| `CREATE_SHEET_ROLE` | Array of roles allowed to create sheets | `[]` |
+| `MODIFY_COLUMNS_BY_API` | Allow column modification via API | `false` |
+| `MODIFY_SHEET_USER` | Array of user IDs allowed to modify sheets | `[]` |
+| `MODIFY_SHEET_ROLE` | Array of roles allowed to modify sheets | `[]` |
+
+### File Upload Runtime Settings
+
+| Key | Description | Default Value |
+|-----|-------------|---------------|
+| `ANONYMOUS_FILE_UPLOAD` | Allow uploads without authentication | `false` |
+| `MAX_FILE_SIZE` | Maximum file size in bytes | `10485760` (10MB) |
+| `FILE_UPLOAD_PUBLIC` | Make uploaded files publicly accessible | `true` |
+
 ## Usage Notes
 
-1. All sensitive values (tokens, secrets) should be stored securely and never exposed in logs or client responses
-2. Boolean flags are stored as string values (`"true"` or `"false"`)
-3. JSON data is stored as stringified JSON in the value field
-4. The Config table is used for application-wide settings, not user-specific data
+1. **Config Table**: All sensitive values (tokens, secrets) should be stored securely and never exposed in logs or client responses
+2. **Config Table**: Boolean flags are stored as string values (`"true"` or `"false"`)
+3. **Config Table**: JSON data is stored as stringified JSON in the value field
+4. **Config Table**: Used for infrastructure settings set during application setup
+5. **_Config Sheet**: All configuration names must be UPPERCASE
+6. **_Config Sheet**: Used for runtime settings that can be modified by users
+7. **_Config Sheet**: Boolean values are stored as strings (`"true"` or `"false"`)
+8. **_Config Sheet**: Array values are stored as JSON strings (e.g., `"[]"` or `"[\"admin\", \"user\"]"`)
 
 ## Adding New Configuration Items
 
-When adding new configuration items:
-
+### For Config Table (Infrastructure Settings):
 1. Update this documentation
 2. Add the key to the config array in `/src/api/setup.ts` if it needs to be loaded on the setup page
 3. Handle the configuration in the appropriate API endpoints
 4. Update the setup form UI if the setting needs to be configurable by users
+
+### For _Config Sheet (Runtime Settings):
+1. Update this documentation
+2. Add the configuration to `src/sheet-schema.ts` in the `addInitialConfigData()` method
+3. Ensure the configuration name is UPPERCASE
+4. Use `getMultipleConfigsFromSheet()` or `getConfigFromSheet()` from `src/utils/sheet-helpers.ts` to read values
+5. Handle the configuration in the appropriate API endpoints

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -12,6 +12,7 @@ import {
 	saveGoogleTokens,
 	type DatabaseConnection
 } from '../google-auth';
+import { getMultipleConfigsFromSheet } from '../utils/sheet-helpers';
 import { authenticateSession } from './auth';
 
 type Bindings = {
@@ -156,8 +157,8 @@ async function uploadToR2(
 		}
 	});
 
-	// Get R2 public URL from configuration
-	const r2PublicUrl = await getConfig(db, 'R2_PUBLIC_URL');
+	// Get R2 public URL from configuration (Config table)
+	const r2PublicUrl = await getConfig(db, 'r2_public_url');
 	if (!r2PublicUrl) {
 		throw new Error('R2 public URL not configured');
 	}
@@ -172,13 +173,10 @@ export function registerFileUploadRoute(app: OpenAPIHono<{ Bindings: Bindings }>
 		try {
 			const db = drizzle(c.env.DB);
 			
-			// Get configuration values
-			const anonymousUpload = await getConfig(db, 'ANONYMOUS_FILE_UPLOAD');
-			const maxFileSize = await getConfig(db, 'MAX_FILE_SIZE');
+			// Get configuration values from Config table (infrastructure configs)
 			const allowedExtensions = await getConfig(db, 'ALLOW_UPLOAD_EXTENSION');
-			const fileUploadPublic = await getConfig(db, 'FILE_UPLOAD_PUBLIC');
 			
-			// Get upload destination
+			// Get upload destination from Config table
 			const uploadDestination = await getConfig(db, 'upload_destination');
 			if (!uploadDestination) {
 				return c.json({
@@ -186,6 +184,51 @@ export function registerFileUploadRoute(app: OpenAPIHono<{ Bindings: Bindings }>
 					error: 'Upload destination not configured'
 				}, 400);
 			}
+			
+			// Get Google credentials and spreadsheet ID for _Config sheet access
+			const spreadsheetId = await getConfig(db, 'spreadsheet_id');
+			if (!spreadsheetId) {
+				return c.json({
+					success: false,
+					error: 'No spreadsheet configured'
+				}, 500);
+			}
+			
+			// Get valid Google tokens
+			let tokens = await getGoogleTokens(db);
+			if (!tokens) {
+				return c.json({
+					success: false,
+					error: 'No valid Google token found'
+				}, 500);
+			}
+			
+			// Check token validity and refresh if needed
+			const isValid = await isTokenValid(db);
+			if (!isValid) {
+				const credentials = await getGoogleCredentials(db);
+				if (credentials && tokens.refresh_token) {
+					tokens = await refreshAccessToken(tokens.refresh_token, credentials);
+					await saveGoogleTokens(db, tokens);
+				} else {
+					return c.json({
+						success: false,
+						error: 'Failed to refresh Google token'
+					}, 500);
+				}
+			}
+			
+			// Get configuration values from _Config sheet (runtime configs)
+			const sheetConfigs = await getMultipleConfigsFromSheet(
+				['ANONYMOUS_FILE_UPLOAD', 'MAX_FILE_SIZE', 'FILE_UPLOAD_PUBLIC'],
+				spreadsheetId,
+				tokens.access_token
+			);
+			
+			const anonymousUpload = sheetConfigs['ANONYMOUS_FILE_UPLOAD'];
+			const maxFileSize = sheetConfigs['MAX_FILE_SIZE'];
+			const fileUploadPublic = sheetConfigs['FILE_UPLOAD_PUBLIC'];
+			
 
 			// Check authentication if required
 			const authHeader = c.req.header('authorization');

--- a/src/sheet-schema.ts
+++ b/src/sheet-schema.ts
@@ -723,7 +723,7 @@ export class SheetsSetupManager {
     
     try {
       // Check if data already exists
-      const existingData = await this.getSheetData('_Config', 'A3:K8');
+      const existingData = await this.getSheetData('_Config', 'A3:K11');
       if (existingData?.values && existingData.values.length > 0) {
         console.log('Configuration data already exists, skipping initialization');
         return;
@@ -736,12 +736,15 @@ export class SheetsSetupManager {
         ['CREATE_SHEET_ROLE', 'CREATE_SHEET_ROLE', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
         ['MODIFY_COLUMNS_BY_API', 'MODIFY_COLUMNS_BY_API', 'false', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
         ['MODIFY_SHEET_USER', 'MODIFY_SHEET_USER', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
-        ['MODIFY_SHEET_ROLE', 'MODIFY_SHEET_ROLE', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]']
+        ['MODIFY_SHEET_ROLE', 'MODIFY_SHEET_ROLE', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['ANONYMOUS_FILE_UPLOAD', 'ANONYMOUS_FILE_UPLOAD', 'false', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['MAX_FILE_SIZE', 'MAX_FILE_SIZE', '10485760', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['FILE_UPLOAD_PUBLIC', 'FILE_UPLOAD_PUBLIC', 'true', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]']
       ];
       
       // Update sheet with initial configuration
       await this.updateSheetData([{
-        range: '_Config!A3:K8',
+        range: '_Config!A3:K11',
         values: configData
       }]);
       


### PR DESCRIPTION
- Move ANONYMOUS_FILE_UPLOAD, MAX_FILE_SIZE, FILE_UPLOAD_PUBLIC to _Config sheet as uppercase configs
- Fix R2_PUBLIC_URL to lowercase (r2_public_url) in Config table
- Update file upload logic to read runtime configs from _Config sheet
- Update documentation to clarify infrastructure vs runtime config separation
- Add new file upload configs to _Config sheet initialization

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and expanded documentation on configuration storage, distinguishing between infrastructure settings and runtime operational settings.
  * Updated usage notes, naming conventions, and instructions for managing configuration items.

* **New Features**
  * File upload settings (anonymous uploads, max file size, public upload flag) are now dynamically retrieved from a Google Sheets configuration, allowing for real-time adjustments without redeploying.

* **Bug Fixes**
  * Improved error handling for missing or invalid configuration and authentication tokens during file uploads.

* **Refactor**
  * Adjusted configuration key naming conventions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->