### PR TITLE
refactor: move ALLOW_UPLOAD_EXTENSION and SESSION_EXPIRED_SECONDS to …

### DIFF
--- a/docs/config-table.md
+++ b/docs/config-table.md
@@ -59,7 +59,6 @@ The Config table stores key-value pairs for application configuration:
 | Key | Description | Example |
 |-----|-------------|---------|
 | `upload_destination` | Selected file upload destination | `Google Drive` or `R2` |
-| `ALLOW_UPLOAD_EXTENSION` | Allowed file extensions/types | `image/*` or `*.jpg,*.png` |
 | `r2_bucket_name` | Cloudflare R2 bucket name | `my-bucket` |
 | `r2_access_key_id` | Cloudflare R2 Access Key ID | `xxxxxxxxxxxxxxxxxx` |
 | `r2_secret_access_key` | Cloudflare R2 Secret Access Key | `xxxxxxxxxxxxxxxxxx` |
@@ -73,7 +72,6 @@ The Config table stores key-value pairs for application configuration:
 |-----|-------------|---------|
 | `reset_token` | Token required to reset setup configuration | Secure random string (min 16 chars) |
 | `setup_completed` | Flag indicating if initial setup is complete | `true` or `false` |
-| `session_expired_seconds` | Session expiration time in seconds (range: 60-2592000) | `3600` (1 hour, default) |
 
 ## _Config Sheet (Runtime Settings)
 
@@ -97,6 +95,13 @@ The _Config sheet stores runtime operational settings that can be modified durin
 | `ANONYMOUS_FILE_UPLOAD` | Allow uploads without authentication | `false` |
 | `MAX_FILE_SIZE` | Maximum file size in bytes | `10485760` (10MB) |
 | `FILE_UPLOAD_PUBLIC` | Make uploaded files publicly accessible | `true` |
+| `ALLOW_UPLOAD_EXTENSION` | Allowed file extensions/types | `image/*` |
+
+### Session Management Settings
+
+| Key | Description | Default Value |
+|-----|-------------|---------------|
+| `SESSION_EXPIRED_SECONDS` | Session expiration time in seconds (range: 60-2592000) | `3600` (1 hour) |
 
 ## Usage Notes
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -10,6 +10,7 @@ import {
 	CONFIG_KEYS,
 	type DatabaseConnection
 } from '../google-auth';
+import { getConfigFromSheet } from '../utils/sheet-helpers';
 import { authStartRoute, authCallbackGetRoute, authCallbackPostRoute, logoutRoute } from '../api-routes';
 
 type Bindings = {
@@ -559,20 +560,32 @@ async function saveSessionToSheet(db: DatabaseConnection, sessionId: string, use
 			throw new Error('No valid Google token found');
 		}
 		
-		// 現在の日時と有効期限（設定可能）
-		const now = new Date();
-		const sessionExpiredSeconds = await getConfig(db, CONFIG_KEYS.SESSION_EXPIRED_SECONDS);
-		let expiredSeconds = sessionExpiredSeconds ? parseInt(sessionExpiredSeconds, 10) : 3600; // デフォルト: 1時間
+		// Check token validity and refresh if needed
+		const isValid = await isTokenValid(db);
+		if (!isValid) {
+			const credentials = await getGoogleCredentials(db);
+			if (credentials && tokens.refresh_token) {
+				tokens = await refreshAccessToken(tokens.refresh_token, credentials);
+				await saveGoogleTokens(db, tokens);
+			} else {
+				throw new Error('Failed to refresh Google token');
+			}
+		}
 		
-		// セッション有効期限の検証（1分〜30日の範囲）
+		// Get session expiration time from _Config sheet (runtime config)
+		const now = new Date();
+		const sessionExpiredSeconds = await getConfigFromSheet('SESSION_EXPIRED_SECONDS', spreadsheetId, tokens.access_token);
+		let expiredSeconds = sessionExpiredSeconds ? parseInt(sessionExpiredSeconds, 10) : 3600; // Default: 1 hour
+		
+		// Validate session expiration time (1 minute to 30 days range)
 		if (isNaN(expiredSeconds) || expiredSeconds < 60 || expiredSeconds > 2592000) {
 			console.warn('Invalid session expiration time:', sessionExpiredSeconds, 'using default 3600 seconds');
-			expiredSeconds = 3600; // デフォルト: 1時間
+			expiredSeconds = 3600; // Default: 1 hour
 		}
 		
 		const expiresAt = new Date(now.getTime() + expiredSeconds * 1000);
 		
-		// セッションデータを準備
+		// Prepare session data
 		const sessionData = [
 			sessionId,                             // id
 			userId,                                // user_id

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -173,10 +173,7 @@ export function registerFileUploadRoute(app: OpenAPIHono<{ Bindings: Bindings }>
 		try {
 			const db = drizzle(c.env.DB);
 			
-			// Get configuration values from Config table (infrastructure configs)
-			const allowedExtensions = await getConfig(db, 'ALLOW_UPLOAD_EXTENSION');
-			
-			// Get upload destination from Config table
+			// Get upload destination from Config table (infrastructure config)
 			const uploadDestination = await getConfig(db, 'upload_destination');
 			if (!uploadDestination) {
 				return c.json({
@@ -220,7 +217,7 @@ export function registerFileUploadRoute(app: OpenAPIHono<{ Bindings: Bindings }>
 			
 			// Get configuration values from _Config sheet (runtime configs)
 			const sheetConfigs = await getMultipleConfigsFromSheet(
-				['ANONYMOUS_FILE_UPLOAD', 'MAX_FILE_SIZE', 'FILE_UPLOAD_PUBLIC'],
+				['ANONYMOUS_FILE_UPLOAD', 'MAX_FILE_SIZE', 'FILE_UPLOAD_PUBLIC', 'ALLOW_UPLOAD_EXTENSION'],
 				spreadsheetId,
 				tokens.access_token
 			);
@@ -228,6 +225,7 @@ export function registerFileUploadRoute(app: OpenAPIHono<{ Bindings: Bindings }>
 			const anonymousUpload = sheetConfigs['ANONYMOUS_FILE_UPLOAD'];
 			const maxFileSize = sheetConfigs['MAX_FILE_SIZE'];
 			const fileUploadPublic = sheetConfigs['FILE_UPLOAD_PUBLIC'];
+			const allowedExtensions = sheetConfigs['ALLOW_UPLOAD_EXTENSION'];
 			
 
 			// Check authentication if required

--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -64,8 +64,7 @@ export function registerSetupMainRoute(app: OpenAPIHono<{ Bindings: Bindings }>)
 				'r2_access_key_id',
 				'r2_secret_access_key',
 				'r2_account_id',
-				'google_drive_folder_id',
-				'session_expired_seconds'
+				'google_drive_folder_id'
 			]);
 
 			// Embed configuration status into HTML
@@ -97,8 +96,8 @@ export function registerSetupMainRoute(app: OpenAPIHono<{ Bindings: Bindings }>)
 				r2SecretAccessKey: configs.r2_secret_access_key || '',
 				r2AccountId: configs.r2_account_id || '',
 				googleDriveFolderId: configs.google_drive_folder_id || '',
-				// Session settings
-				sessionExpiredSeconds: configs.session_expired_seconds || '3600' // Default: 1 hour
+				// Session settings (now moved to _Config sheet)
+				sessionExpiredSeconds: '3600' // Default: 1 hour
 			};
 
 			// Load template with configuration data injected

--- a/src/sheet-schema.ts
+++ b/src/sheet-schema.ts
@@ -723,7 +723,7 @@ export class SheetsSetupManager {
     
     try {
       // Check if data already exists
-      const existingData = await this.getSheetData('_Config', 'A3:K11');
+      const existingData = await this.getSheetData('_Config', 'A3:K13');
       if (existingData?.values && existingData.values.length > 0) {
         console.log('Configuration data already exists, skipping initialization');
         return;
@@ -739,12 +739,14 @@ export class SheetsSetupManager {
         ['MODIFY_SHEET_ROLE', 'MODIFY_SHEET_ROLE', '[]', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
         ['ANONYMOUS_FILE_UPLOAD', 'ANONYMOUS_FILE_UPLOAD', 'false', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
         ['MAX_FILE_SIZE', 'MAX_FILE_SIZE', '10485760', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
-        ['FILE_UPLOAD_PUBLIC', 'FILE_UPLOAD_PUBLIC', 'true', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]']
+        ['FILE_UPLOAD_PUBLIC', 'FILE_UPLOAD_PUBLIC', 'true', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['ALLOW_UPLOAD_EXTENSION', 'ALLOW_UPLOAD_EXTENSION', 'image/*', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]'],
+        ['SESSION_EXPIRED_SECONDS', 'SESSION_EXPIRED_SECONDS', '3600', new Date().toISOString(), new Date().toISOString(), 'false', 'false', '[]', '[]', '[]', '[]']
       ];
       
       // Update sheet with initial configuration
       await this.updateSheetData([{
-        range: '_Config!A3:K11',
+        range: '_Config!A3:K13',
         values: configData
       }]);
       


### PR DESCRIPTION
…_Config sheet

- Move ALLOW_UPLOAD_EXTENSION from Config table to _Config sheet as uppercase config
- Move SESSION_EXPIRED_SECONDS from Config table to _Config sheet as uppercase config
- Update file upload logic to read ALLOW_UPLOAD_EXTENSION from _Config sheet
- Update session creation logic to read SESSION_EXPIRED_SECONDS from _Config sheet with token validation
- Update _Config sheet initialization to include new configurations
- Update documentation to reflect moved configurations
- Convert Japanese comments to English in auth.ts

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring allowed file upload extensions and session expiration time directly from the runtime configuration sheet.

* **Documentation**
  * Updated documentation to reflect that `ALLOW_UPLOAD_EXTENSION` and `SESSION_EXPIRED_SECONDS` are now managed via the runtime configuration sheet instead of the infrastructure config table.

* **Refactor**
  * Consolidated configuration retrieval for file uploads and session expiration to use the runtime configuration sheet for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->