### PR TITLE
fix: Resolve auth OpenAPI integration type compatibility issues

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,8 +12,7 @@ import { sheetsPostHandler } from './v1/sheets/post';
 import storagesRouter, { uploadFileRoute, deleteFileRoute } from './v1/storages/route';
 import storagesPostHandler from './v1/storages/post';
 import storagesDeleteHandler from './v1/storages/delete';
-import authRouter, { loginRoute, callbackRoute, logoutRoute, meRoute } from './v1/auth';
-import { loginHandler } from './v1/auth/login/get';
+import authRouter, { callbackRoute, logoutRoute, meRoute } from './v1/auth';
 import { callbackHandler } from './v1/auth/callback/get';
 import { logoutHandler } from './v1/auth/logout/post';
 import { meHandler } from './v1/auth/me/get';
@@ -54,11 +53,11 @@ api.openapi(createSheetRoute, sheetsPostHandler);
 api.openapi(uploadFileRoute, storagesPostHandler);
 api.openapi(deleteFileRoute, storagesDeleteHandler);
 
-// Auth routes - direct OpenAPI mount
-api.openapi(loginRoute, loginHandler as any);
-api.openapi(callbackRoute, callbackHandler as any);
-api.openapi(logoutRoute, logoutHandler as any);
-api.openapi(meRoute, meHandler as any);
+// Auth routes - OpenAPI mount (excluding login which uses 302 redirect)
+// Login endpoint uses traditional routing due to redirect response
+api.openapi(callbackRoute, callbackHandler);
+api.openapi(logoutRoute, logoutHandler);
+api.openapi(meRoute, meHandler);
 
 // Storage routes - backwards compatibility
 v1.route('/storages', storagesRouter);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,13 +12,11 @@ import { sheetsPostHandler } from './v1/sheets/post';
 import storagesRouter, { uploadFileRoute, deleteFileRoute } from './v1/storages/route';
 import storagesPostHandler from './v1/storages/post';
 import storagesDeleteHandler from './v1/storages/delete';
-import authRouter from './v1/auth';
-// TODO: Re-enable OpenAPI integration when type compatibility is fixed
-// import { loginRoute, callbackRoute, logoutRoute, meRoute } from './v1/auth';
-// import { loginHandler } from './v1/auth/login/get';
-// import { callbackHandler } from './v1/auth/callback/get';
-// import { logoutHandler } from './v1/auth/logout/post';
-// import { meHandler } from './v1/auth/me/get';
+import authRouter, { loginRoute, callbackRoute, logoutRoute, meRoute } from './v1/auth';
+import { loginHandler } from './v1/auth/login/get';
+import { callbackHandler } from './v1/auth/callback/get';
+import { logoutHandler } from './v1/auth/logout/post';
+import { meHandler } from './v1/auth/me/get';
 import type { Env } from '@/types/env';
 
 /**
@@ -56,12 +54,11 @@ api.openapi(createSheetRoute, sheetsPostHandler);
 api.openapi(uploadFileRoute, storagesPostHandler);
 api.openapi(deleteFileRoute, storagesDeleteHandler);
 
-// Auth routes - OpenAPI mount (temporarily disabled due to type mismatches)
-// TODO: Fix type compatibility between handlers and OpenAPI schemas
-// api.openapi(loginRoute, loginHandler);
-// api.openapi(callbackRoute, callbackHandler);
-// api.openapi(logoutRoute, logoutHandler);
-// api.openapi(meRoute, meHandler);
+// Auth routes - direct OpenAPI mount
+api.openapi(loginRoute, loginHandler as any);
+api.openapi(callbackRoute, callbackHandler as any);
+api.openapi(logoutRoute, logoutHandler as any);
+api.openapi(meRoute, meHandler as any);
 
 // Storage routes - backwards compatibility
 v1.route('/storages', storagesRouter);

--- a/src/api/v1/auth/callback/get.ts
+++ b/src/api/v1/auth/callback/get.ts
@@ -31,7 +31,7 @@ export const callbackHandler = async (c: Context<{ Bindings: Env }>) => {
         error: error,
         message: errorDescription || 'Authentication failed',
         authenticated: false
-      }, 400);
+      }, 400 as const);
     }
 
     // 必須パラメータの検証
@@ -41,7 +41,7 @@ export const callbackHandler = async (c: Context<{ Bindings: Env }>) => {
         error: 'missing_parameters',
         message: 'Missing required parameters: code and state',
         authenticated: false
-      }, 400);
+      }, 400 as const);
     }
 
     // State検証（CSRF対策）
@@ -52,7 +52,7 @@ export const callbackHandler = async (c: Context<{ Bindings: Env }>) => {
         error: 'invalid_state',
         message: 'Invalid state parameter',
         authenticated: false
-      }, 400);
+      }, 400 as const);
     }
 
     // リダイレクトURIの構築
@@ -122,34 +122,25 @@ export const callbackHandler = async (c: Context<{ Bindings: Env }>) => {
     // Stateクッキー削除
     deleteCookie(c, 'auth_state');
 
-    // TODO: Google Sheets が利用可能になったら _User シートから取得
-    // 現在はAuth0から取得したユーザー情報を直接使用
-    const finalUserData = {
-      id: userInfo.sub,
-      email: userInfo.email,
-      name: userInfo.name || '',
-      picture: userInfo.picture || '',
-      created_at: now,
-      last_login: now
-    };
+    // Note: User data is stored in _User sheet for future reference
 
-    // 成功レスポンス
+    // Success response matching CallbackSuccessSchema
     return c.json({
       success: true,
       user: {
         id: userInfo.sub,
         email: userInfo.email,
-        name: userInfo.name,
-        picture: userInfo.picture,
-        created_at: finalUserData.created_at || now,
-        last_login: finalUserData.last_login || now
+        name: userInfo.name || null,
+        picture: userInfo.picture || null,
+        created_at: now,
+        last_login: now
       },
       session: {
         session_id: sessionId,
         expires_at: expiresAt.toISOString()
       },
       authenticated: true
-    });
+    }, 200 as const);
 
   } catch (error) {
     console.error('Callback error:', error);
@@ -168,9 +159,8 @@ export const callbackHandler = async (c: Context<{ Bindings: Env }>) => {
       success: false,
       error: 'authentication_failed',
       message: 'Authentication process failed',
-      details: errorMessage, // 開発用の詳細情報
       authenticated: false
-    }, 500);
+    }, 500 as const);
   }
 };
 

--- a/src/api/v1/auth/logout/post.ts
+++ b/src/api/v1/auth/logout/post.ts
@@ -17,7 +17,7 @@ export const logoutHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'invalid_request',
         message: 'Invalid request headers'
-      }, 400);
+      }, 400 as const);
     }
 
     // Origin/Refererヘッダーの検証
@@ -31,7 +31,7 @@ export const logoutHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'missing_origin_headers',
         message: 'Origin or Referer header is required'
-      }, 400);
+      }, 400 as const);
     }
     
     // 存在するヘッダーを検証
@@ -41,7 +41,7 @@ export const logoutHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'invalid_origin',
         message: 'Invalid request origin'
-      }, 400);
+      }, 400 as const);
     }
 
     // セッションIDをCookieから取得
@@ -52,7 +52,7 @@ export const logoutHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'unauthorized',
         message: 'No active session found'
-      }, 401);
+      }, 401 as const);
     }
 
     // データベース接続
@@ -91,7 +91,7 @@ export const logoutHandler = async (c: Context<{ Bindings: Env }>) => {
     return c.json({
       success: true,
       message: 'Successfully logged out'
-    });
+    }, 200 as const);
 
   } catch (error) {
     console.error('Logout error:', error);
@@ -103,7 +103,7 @@ export const logoutHandler = async (c: Context<{ Bindings: Env }>) => {
       success: false,
       error: 'logout_failed',
       message: 'Logout process failed'
-    }, 500);
+    }, 500 as const);
   }
 };
 

--- a/src/api/v1/auth/me/get.ts
+++ b/src/api/v1/auth/me/get.ts
@@ -18,7 +18,7 @@ export const meHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'unauthorized',
         message: 'Authentication required'
-      }, 401);
+      }, 401 as const);
     }
 
     // データベース接続
@@ -38,7 +38,7 @@ export const meHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'unauthorized',
         message: 'Authentication required'
-      }, 401);
+      }, 401 as const);
     }
 
     const session = sessions[0];
@@ -59,7 +59,7 @@ export const meHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'session_expired',
         message: 'Session has expired'
-      }, 401);
+      }, 401 as const);
     }
 
     // ユーザーデータをパース
@@ -76,17 +76,17 @@ export const meHandler = async (c: Context<{ Bindings: Env }>) => {
         success: false,
         error: 'server_error',
         message: 'Failed to retrieve user information'
-      }, 500);
+      }, 500 as const);
     }
 
-    // レスポンス返却
+    // Response matching MeSuccessSchema
     return c.json({
       success: true,
       user: {
         id: userData.sub,
-        name: userData.name,
+        name: userData.name || null,
         email: userData.email,
-        picture: userData.picture,
+        picture: userData.picture || null,
         email_verified: userData.email_verified,
         updated_at: userData.updated_at,
         iss: userData.iss,
@@ -99,9 +99,9 @@ export const meHandler = async (c: Context<{ Bindings: Env }>) => {
       session: {
         session_id: session.session_id,
         expires_at: session.expires_at,
-        created_at: session.created_at
+        created_at: session.created_at || new Date().toISOString()
       }
-    });
+    }, 200 as const);
 
   } catch (error) {
     console.error('Auth me error:', error);
@@ -113,7 +113,7 @@ export const meHandler = async (c: Context<{ Bindings: Env }>) => {
       success: false,
       error: 'server_error',
       message: 'Failed to retrieve user information'
-    }, 500);
+    }, 500 as const);
   }
 };
 


### PR DESCRIPTION
## Summary
- Fixed TypeScript type compatibility issues preventing auth endpoints from appearing in OpenAPI documentation
- Resolved handler response types to match OpenAPI schemas exactly without using type assertions
- Ensured all auth endpoints now properly integrate with `/api/v1/doc`

## Changes Made
- **Callback Handler**: Fixed null handling for `name` and `picture` fields, added explicit status codes
- **Me Handler**: Resolved `session.created_at` null value handling, standardized error responses
- **Logout Handler**: Added proper status codes to all response paths
- **API Integration**: Cleaned up OpenAPI route registration without type assertions

## Test Plan
- [x] Verified auth endpoints appear in `/api/v1/doc` OpenAPI documentation
- [x] Confirmed TypeScript compilation without errors
- [x] Tested development server startup and OpenAPI doc generation
- [x] Validated response schemas match OpenAPI definitions exactly

## Technical Details
- Followed patterns from existing implementations (health, setup, storages)
- Used `as const` for proper status code type inference
- Maintained backward compatibility with traditional Hono routing
- Excluded login endpoint from OpenAPI due to 302 redirect response incompatibility

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of authentication-related API responses, ensuring user data fields are always present and default to null or current timestamps when missing.
  * Enhanced type precision for API response status codes, reducing the potential for type-related issues.

* **Chores**
  * Re-enabled certain authentication endpoints in the OpenAPI documentation, making them visible and accessible for API consumers. The login route remains handled separately due to its redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->