### PR TITLE
Add database schema for configs, sessions, and cache

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,20 @@
-language: "ja"
-tone_instructions: "ワンピースのルフィー風に堂々とした口調で"
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: ja-JP
+tone_instructions: ワンピースのルフィー風に堂々とした口調で
 early_access: true
+reviews:
+  auto_apply_labels: true
+  pre_merge_checks:
+    custom_checks:
+      - mode: warning
+        instructions: 新しく作られたクラス、関数のユニットテストのカバレッジ率は80%以上とする（TypeScriptのみ）
+        name: Unit Test
+      - mode: warning
+        instructions: packages/api 以下のファイルについて、Hono OpenAPIを使ってドキュメントを記述されていることを確認する。入力値の検証はZodを利用する。
+        name: API Document
+      - mode: warning
+        instructions: packages 以下における、異なるパッケージの呼び出しについて、必ず root/src/index.ts を通して行うこと（kagaribiの作法）。importも禁止。
+        name: Package Safety
+issue_enrichment:
+  auto_enrich:
+    enabled: true

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,12 +1,33 @@
-import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, integer, text, index } from 'drizzle-orm/sqlite-core';
 
 // SheetDB用のテーブル定義
-// 必要に応じてここにテーブルを追加してください
 
-// 例:
-// export const spreadsheets = sqliteTable('spreadsheets', {
-//   id: integer('id').primaryKey({ autoIncrement: true }),
-//   name: text('name').notNull(),
-//   googleDriveId: text('google_drive_id').notNull(),
-//   createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()).notNull(),
-// });
+// 設定管理テーブル
+export const configs = sqliteTable('configs', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  key: text('key').notNull().unique(),
+  value: text('value').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()).notNull(),
+});
+
+// セッション管理テーブル
+export const sessions = sqliteTable('sessions', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  userId: text('user_id').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()).notNull(),
+  expiredAt: integer('expired_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()).notNull(),
+}, (table) => ({
+  userIdIdx: index('sessions_user_id_idx').on(table.userId),
+}));
+
+// キャッシュ管理テーブル
+export const cache = sqliteTable('cache', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull().unique(),
+  data: text('data').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()).notNull(),
+  expiredAt: integer('expired_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()).notNull(),
+});

--- a/app/drizzle/0000_damp_hercules.sql
+++ b/app/drizzle/0000_damp_hercules.sql
@@ -1,0 +1,28 @@
+CREATE TABLE `cache` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`data` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`expired_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `cache_name_unique` ON `cache` (`name`);--> statement-breakpoint
+CREATE TABLE `configs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`key` text NOT NULL,
+	`value` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `configs_key_unique` ON `configs` (`key`);--> statement-breakpoint
+CREATE TABLE `sessions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`expired_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `sessions_user_id_idx` ON `sessions` (`user_id`);

--- a/app/drizzle/meta/0000_snapshot.json
+++ b/app/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,184 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "47821afc-18d5-4384-9c6f-be6a0e239b14",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "cache": {
+      "name": "cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cache_name_unique": {
+          "name": "cache_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "configs": {
+      "name": "configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "configs_key_unique": {
+          "name": "configs_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1773468412886,
+      "tag": "0000_damp_hercules",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add D1 database schema with three core tables for SheetDB application.

- configs: Application configuration storage
- sessions: User session management
- cache: Data caching layer

## Changes

### Database Schema
- Added `configs` table with unique key constraint
- Added `sessions` table with user_id index
- Added `cache` table with unique name constraint
- All tables include created_at, updated_at timestamps

### Migrations
- Generated SQL migration file: `0000_damp_hercules.sql`
- Applied to local D1 database
- Applied to production D1 database

### Configuration
- Updated CodeRabbit configuration

## Database Details

**configs table:**
- `id`: Primary key (auto-increment)
- `key`: Unique configuration key
- `value`: Configuration value
- `created_at`, `updated_at`: Timestamps

**sessions table:**
- `id`: Primary key (auto-increment)
- `user_id`: User identifier (indexed)
- `created_at`, `expired_at`, `updated_at`: Timestamps

**cache table:**
- `id`: Primary key (auto-increment)
- `name`: Unique cache key
- `data`: Cached data (JSON string)
- `created_at`, `expired_at`, `updated_at`: Timestamps

## Test Plan

- [x] Migration files generated successfully
- [x] Local D1 tables created and verified
- [x] Production D1 tables created and verified
- [x] All indexes and constraints applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ユーザーセッション管理、設定データの永続化、およびデータキャッシング機能をサポートするデータベーススキーマを追加しました。

* **その他**
  * コード品質チェックルールを強化し、ユニットテストカバレッジ、APIドキュメンテーション、およびパッケージの安全性に関する要件を導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->